### PR TITLE
Fix historical data-label mismatch for GIPL outputs

### DIFF
--- a/iem/gipl2_4km/ingest.json
+++ b/iem/gipl2_4km/ingest.json
@@ -9,7 +9,7 @@
     "automated": true
   },
   "input": {
-    "coverage_id": "test_iem_gipl_magt_alt_4km_wmt",
+    "coverage_id": "test_iem_gipl_magt_alt_4km",
     "paths": [
       "gipl_alt_magt_4km.nc"
     ]
@@ -24,9 +24,29 @@
         "metadata": {
           "type": "xml",
           "global": {
-            "Title": "'CMIP5 GIPL Model Output 4 km magt alt'"
-          }
-        },
+            "Title": "'CMIP5 GIPL Model Output 4 km magt alt'",
+            "Encoding": {"'magt'": "'°C'",
+ 			 "'alt'": "'m'",
+			 "eras": {"'1995'": 0,
+ 			          "'2025'": 1,
+ 			          "'2050'": 2,
+                                  "'2075'": 3,
+                                  "'2095'": 4
+                                 },
+                         "models": {"'cruts31'": 0,
+                                    "'gfdlcm3'": 1,
+                                    "'gisse2r'": 2,
+                                    "'ipslcm5alr'": 3,
+                                    "'mricgcm3'": 4,
+                                    "'ncarccsm4'": 5
+                                   },
+                         "scenarios": {"'historical'": 0,
+	                               "'rcp45'": 1,
+	                               "'rcp85'": 2
+                                      }
+                        }
+                    }
+                    },
         "slicer": {
           "type": "netcdf",
           "pixelIsPoint": true,

--- a/iem/gipl2_4km/preprocess_GIPL_4km_alt_and_magt.ipynb
+++ b/iem/gipl2_4km/preprocess_GIPL_4km_alt_and_magt.ipynb
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "id": "be69c8e5",
    "metadata": {},
    "outputs": [
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "id": "bfd88b2c",
    "metadata": {},
    "outputs": [
@@ -177,7 +177,7 @@
        " 'NODATA_value -9999']"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "id": "a6a9062d",
    "metadata": {},
    "outputs": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "id": "fcdaa5ff",
    "metadata": {},
    "outputs": [],
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 6,
    "id": "6cf7c828",
    "metadata": {},
    "outputs": [
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 7,
    "id": "c152ccab",
    "metadata": {},
    "outputs": [],
@@ -342,7 +342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 8,
    "id": "6356df83",
    "metadata": {},
    "outputs": [
@@ -485,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 11,
    "id": "718812f1",
    "metadata": {},
    "outputs": [
@@ -493,7 +493,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[PosixPath('input_data/Permafrost/geotiff/magt_cruts31_historical_era1995_1986to2005.tif'), PosixPath('input_data/Permafrost/geotiff/alt_cruts31_historical_era1995_1986to2005.tif')]\n"
+      "[PosixPath('input_data/Permafrost/Base/ALT.asc'), PosixPath('input_data/Permafrost/Base/MAGT.asc')]\n",
+      "[PosixPath('input_data/Permafrost/geotiff/alt_cruts31_historical_era1995_1986to2005.tif'), PosixPath('input_data/Permafrost/geotiff/magt_cruts31_historical_era1995_1986to2005.tif')]\n"
      ]
     }
    ],
@@ -502,8 +503,9 @@
     "target_dir = Path(\"input_data/Permafrost/Base/\")\n",
     "out_dir = Path(\"input_data/Permafrost/geotiff/\")\n",
     "hist_asc_fps = [target_dir.joinpath(fp.name) for fp in target_dir.glob(\"*.asc\")]\n",
-    "out_names = [out_dir.joinpath(\"magt_\" + historical_suffix),\n",
-    "             out_dir.joinpath(\"alt_\" + historical_suffix)]\n",
+    "out_names = [out_dir.joinpath(\"alt_\" + historical_suffix),\n",
+    "             out_dir.joinpath(\"magt_\" + historical_suffix)]\n",
+    "print(hist_asc_fps)\n",
     "print(out_names)"
    ]
   },
@@ -517,7 +519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 12,
    "id": "6a48a2bc",
    "metadata": {},
    "outputs": [],
@@ -530,7 +532,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 13,
    "id": "b4f623cf",
    "metadata": {},
    "outputs": [
@@ -580,12 +582,13 @@
    "id": "7b0ee26d",
    "metadata": {},
    "source": [
-    "Execute the crop script to use the above shapefile to bound the raster extent."
+    "Execute the crop script to use the above shapefile to bound the raster extent:\n",
+    "`bash crop_geotiff_dir_to_akpoly.sh`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 14,
    "id": "fa26634b",
    "metadata": {},
    "outputs": [
@@ -595,7 +598,7 @@
        "PosixPath('input_data/Permafrost/geotiff/cropped/alt_cruts31_historical_era1995_1986to2005.tif')"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -609,7 +612,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "0e49ff7d",
    "metadata": {},
    "outputs": [],
@@ -641,7 +644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "4b372724",
    "metadata": {},
    "outputs": [
@@ -664,7 +667,7 @@
        "       dtype=float32)}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -707,7 +710,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "8222663c",
    "metadata": {},
    "outputs": [
@@ -741,7 +744,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "26b4a85c",
    "metadata": {},
    "outputs": [
@@ -769,7 +772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "id": "36724f7c",
    "metadata": {},
    "outputs": [
@@ -962,7 +965,7 @@
        "[82 rows x 7 columns]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -982,7 +985,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "id": "defd5152",
    "metadata": {},
    "outputs": [],
@@ -1006,7 +1009,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "id": "b02f9199",
    "metadata": {},
    "outputs": [
@@ -1016,7 +1019,7 @@
        "['magt', 'alt']"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1027,7 +1030,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "id": "4ae691de",
    "metadata": {},
    "outputs": [
@@ -1055,9 +1058,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "id": "640ca8df",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -1437,9 +1442,9 @@
        "    gisse2r:     2\n",
        "    ipslcm5alr:  3\n",
        "    mricgcm3:    4\n",
-       "    ncarccsm4:   5</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-bb6601b3-bfd2-4c5d-aa71-40342d861a2f' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-bb6601b3-bfd2-4c5d-aa71-40342d861a2f' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>era</span>: 5</li><li><span class='xr-has-index'>model</span>: 6</li><li><span class='xr-has-index'>scenario</span>: 3</li><li><span class='xr-has-index'>y</span>: 489</li><li><span class='xr-has-index'>x</span>: 914</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-2b7271f3-cbfc-429f-a5ba-729ad37d117e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-2b7271f3-cbfc-429f-a5ba-729ad37d117e' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>era</span></div><div class='xr-var-dims'>(era)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4</div><input id='attrs-8df193fe-c6d1-489f-b0df-7b109fcc97bc' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-8df193fe-c6d1-489f-b0df-7b109fcc97bc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eb2d1ba8-8da1-4175-b8be-d78bf631af48' class='xr-var-data-in' type='checkbox'><label for='data-eb2d1ba8-8da1-4175-b8be-d78bf631af48' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1, 2, 3, 4])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>model</span></div><div class='xr-var-dims'>(model)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 5</div><input id='attrs-73e62b8a-300b-47bf-81b4-bc1d0ae7108e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-73e62b8a-300b-47bf-81b4-bc1d0ae7108e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fa4ef861-ffe1-4ed5-83d1-cdf38dc03aa3' class='xr-var-data-in' type='checkbox'><label for='data-fa4ef861-ffe1-4ed5-83d1-cdf38dc03aa3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1, 2, 3, 4, 5])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>scenario</span></div><div class='xr-var-dims'>(scenario)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2</div><input id='attrs-fae83547-f853-40cf-9046-6b9bcf1507e1' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-fae83547-f853-40cf-9046-6b9bcf1507e1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5cb72624-190e-46a3-a804-87f29e9a2a04' class='xr-var-data-in' type='checkbox'><label for='data-5cb72624-190e-46a3-a804-87f29e9a2a04' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1, 2])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.373e+06 2.369e+06 ... 4.214e+05</div><input id='attrs-d9205a99-fcef-41d1-b2d1-2c536a9e3ac4' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d9205a99-fcef-41d1-b2d1-2c536a9e3ac4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d9b6fe89-3323-4255-9df5-6db84b2a2081' class='xr-var-data-in' type='checkbox'><label for='data-d9b6fe89-3323-4255-9df5-6db84b2a2081' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2373412.93264, 2369412.93264, 2365412.93264, ...,  429412.93264,\n",
-       "        425412.93264,  421412.93264])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-2.164e+06 -2.16e+06 ... 1.488e+06</div><input id='attrs-109df17b-1074-48ef-8804-b18e4d26fd38' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-109df17b-1074-48ef-8804-b18e4d26fd38' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-185b7c7b-4e14-4fec-82b2-3458f5987c06' class='xr-var-data-in' type='checkbox'><label for='data-185b7c7b-4e14-4fec-82b2-3458f5987c06' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-2164223.20581, -2160223.20581, -2156223.20581, ...,  1479776.79419,\n",
-       "        1483776.79419,  1487776.79419])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d4a21bc0-7965-4b72-a8de-d1f774dde75b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d4a21bc0-7965-4b72-a8de-d1f774dde75b' class='xr-section-summary' >Data variables: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>magt</span></div><div class='xr-var-dims'>(era, model, scenario, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-9.999e+03 ... -9.999e+03</div><input id='attrs-8ffd0fe8-fc04-4e46-9ff8-0979d8ac81ac' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-8ffd0fe8-fc04-4e46-9ff8-0979d8ac81ac' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-250745c0-95c6-4aec-923b-7ea314546559' class='xr-var-data-in' type='checkbox'><label for='data-250745c0-95c6-4aec-923b-7ea314546559' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[[[[-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
+       "    ncarccsm4:   5</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-112abc1e-060a-4237-adfd-9fa403902842' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-112abc1e-060a-4237-adfd-9fa403902842' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>era</span>: 5</li><li><span class='xr-has-index'>model</span>: 6</li><li><span class='xr-has-index'>scenario</span>: 3</li><li><span class='xr-has-index'>y</span>: 489</li><li><span class='xr-has-index'>x</span>: 914</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-b5026283-ca80-41ab-87b3-4ee9824c9ef4' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b5026283-ca80-41ab-87b3-4ee9824c9ef4' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>era</span></div><div class='xr-var-dims'>(era)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4</div><input id='attrs-76fa9114-8fff-4478-85fc-ce243e54bfdb' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-76fa9114-8fff-4478-85fc-ce243e54bfdb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-47909ffe-eade-48ba-993a-5fdd528a5b10' class='xr-var-data-in' type='checkbox'><label for='data-47909ffe-eade-48ba-993a-5fdd528a5b10' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1, 2, 3, 4])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>model</span></div><div class='xr-var-dims'>(model)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 5</div><input id='attrs-634a6860-6278-4764-9d48-cd244031780b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-634a6860-6278-4764-9d48-cd244031780b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b817e4dc-cfba-4353-8ab7-261329f310a0' class='xr-var-data-in' type='checkbox'><label for='data-b817e4dc-cfba-4353-8ab7-261329f310a0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1, 2, 3, 4, 5])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>scenario</span></div><div class='xr-var-dims'>(scenario)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2</div><input id='attrs-0fac5714-36d9-48bf-8e23-5b91f1240031' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-0fac5714-36d9-48bf-8e23-5b91f1240031' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ecbb7607-6575-4ec1-bfcf-6750adeec77c' class='xr-var-data-in' type='checkbox'><label for='data-ecbb7607-6575-4ec1-bfcf-6750adeec77c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1, 2])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.373e+06 2.369e+06 ... 4.214e+05</div><input id='attrs-fd1afdb1-9502-44c2-b286-f1a008742d33' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-fd1afdb1-9502-44c2-b286-f1a008742d33' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-988c3f3e-954f-4e55-9125-92d3f2d91687' class='xr-var-data-in' type='checkbox'><label for='data-988c3f3e-954f-4e55-9125-92d3f2d91687' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2373412.93264, 2369412.93264, 2365412.93264, ...,  429412.93264,\n",
+       "        425412.93264,  421412.93264])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-2.164e+06 -2.16e+06 ... 1.488e+06</div><input id='attrs-619e7228-3bd4-4270-84e2-753e1494edce' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-619e7228-3bd4-4270-84e2-753e1494edce' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7db93fa4-1848-4d81-9ae0-8f97feeaf6fd' class='xr-var-data-in' type='checkbox'><label for='data-7db93fa4-1848-4d81-9ae0-8f97feeaf6fd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-2164223.20581, -2160223.20581, -2156223.20581, ...,  1479776.79419,\n",
+       "        1483776.79419,  1487776.79419])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-04c95de6-cfae-4237-8dd4-d6d650dd9a2a' class='xr-section-summary-in' type='checkbox'  checked><label for='section-04c95de6-cfae-4237-8dd4-d6d650dd9a2a' class='xr-section-summary' >Data variables: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>magt</span></div><div class='xr-var-dims'>(era, model, scenario, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-9.999e+03 ... -9.999e+03</div><input id='attrs-31f8253c-54a5-4643-885c-9b5cba85ee93' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-31f8253c-54a5-4643-885c-9b5cba85ee93' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2b8613d8-15ec-4e38-8138-a9fe3d31a5b6' class='xr-var-data-in' type='checkbox'><label for='data-2b8613d8-15ec-4e38-8138-a9fe3d31a5b6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[[[[-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "          [-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "          [-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "          ...,\n",
@@ -1479,7 +1484,7 @@
        "          [-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "          [-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "          [-9999., -9999., -9999., ..., -9999., -9999., -9999.]]]]],\n",
-       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>alt</span></div><div class='xr-var-dims'>(era, model, scenario, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-9.999e+03 ... -9.999e+03</div><input id='attrs-7ed0283e-d0c6-4cee-8709-78ce8ad23895' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7ed0283e-d0c6-4cee-8709-78ce8ad23895' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d487421c-f28a-4069-86ec-2c028e230b11' class='xr-var-data-in' type='checkbox'><label for='data-d487421c-f28a-4069-86ec-2c028e230b11' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[[[[-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
+       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>alt</span></div><div class='xr-var-dims'>(era, model, scenario, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-9.999e+03 ... -9.999e+03</div><input id='attrs-6fe2d3d5-3126-4402-8246-c292cd29d2ee' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-6fe2d3d5-3126-4402-8246-c292cd29d2ee' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6b208370-d4d2-441f-b452-3427515d7cd3' class='xr-var-data-in' type='checkbox'><label for='data-6b208370-d4d2-441f-b452-3427515d7cd3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[[[[-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "          [-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "          [-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "          ...,\n",
@@ -1519,7 +1524,7 @@
        "          [-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "          [-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "          [-9999., -9999., -9999., ..., -9999., -9999., -9999.]]]]],\n",
-       "      dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1dba258a-0343-4755-bd77-ca6d59f72967' class='xr-section-summary-in' type='checkbox'  ><label for='section-1dba258a-0343-4755-bd77-ca6d59f72967' class='xr-section-summary' >Attributes: <span>(16)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>magt :</span></dt><dd>°C</dd><dt><span>alt :</span></dt><dd>m</dd><dt><span>1995 :</span></dt><dd>0</dd><dt><span>2025 :</span></dt><dd>1</dd><dt><span>2050 :</span></dt><dd>2</dd><dt><span>2075 :</span></dt><dd>3</dd><dt><span>2095 :</span></dt><dd>4</dd><dt><span>historical :</span></dt><dd>0</dd><dt><span>rcp45 :</span></dt><dd>1</dd><dt><span>rcp85 :</span></dt><dd>2</dd><dt><span>cruts31 :</span></dt><dd>0</dd><dt><span>gfdlcm3 :</span></dt><dd>1</dd><dt><span>gisse2r :</span></dt><dd>2</dd><dt><span>ipslcm5alr :</span></dt><dd>3</dd><dt><span>mricgcm3 :</span></dt><dd>4</dd><dt><span>ncarccsm4 :</span></dt><dd>5</dd></dl></div></li></ul></div></div>"
+       "      dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-2ed88325-b47e-4aab-9180-ce4dbc677398' class='xr-section-summary-in' type='checkbox'  ><label for='section-2ed88325-b47e-4aab-9180-ce4dbc677398' class='xr-section-summary' >Attributes: <span>(16)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>magt :</span></dt><dd>°C</dd><dt><span>alt :</span></dt><dd>m</dd><dt><span>1995 :</span></dt><dd>0</dd><dt><span>2025 :</span></dt><dd>1</dd><dt><span>2050 :</span></dt><dd>2</dd><dt><span>2075 :</span></dt><dd>3</dd><dt><span>2095 :</span></dt><dd>4</dd><dt><span>historical :</span></dt><dd>0</dd><dt><span>rcp45 :</span></dt><dd>1</dd><dt><span>rcp85 :</span></dt><dd>2</dd><dt><span>cruts31 :</span></dt><dd>0</dd><dt><span>gfdlcm3 :</span></dt><dd>1</dd><dt><span>gisse2r :</span></dt><dd>2</dd><dt><span>ipslcm5alr :</span></dt><dd>3</dd><dt><span>mricgcm3 :</span></dt><dd>4</dd><dt><span>ncarccsm4 :</span></dt><dd>5</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -1549,7 +1554,7 @@
        "    ncarccsm4:   5"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1579,7 +1584,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "id": "1e7de84a",
    "metadata": {},
    "outputs": [],
@@ -1589,7 +1594,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "id": "7b39530c",
    "metadata": {},
    "outputs": [
@@ -1961,16 +1966,16 @@
        "    model     int64 2\n",
        "    scenario  int64 1\n",
        "  * y         (y) float64 2.373e+06 2.369e+06 2.365e+06 ... 4.254e+05 4.214e+05\n",
-       "  * x         (x) float64 -2.164e+06 -2.16e+06 ... 1.484e+06 1.488e+06</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'alt'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 489</li><li><span class='xr-has-index'>x</span>: 914</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-3fd75e2c-70ba-43ea-a29c-179c8a12e5d8' class='xr-array-in' type='checkbox' checked><label for='section-3fd75e2c-70ba-43ea-a29c-179c8a12e5d8' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>-9.999e+03 -9.999e+03 -9.999e+03 ... -9.999e+03 -9.999e+03 -9.999e+03</span></div><div class='xr-array-data'><pre>array([[-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
+       "  * x         (x) float64 -2.164e+06 -2.16e+06 ... 1.484e+06 1.488e+06</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'alt'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 489</li><li><span class='xr-has-index'>x</span>: 914</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-0e40d3aa-3259-49be-83e6-5192a3ce97c0' class='xr-array-in' type='checkbox' checked><label for='section-0e40d3aa-3259-49be-83e6-5192a3ce97c0' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>-9.999e+03 -9.999e+03 -9.999e+03 ... -9.999e+03 -9.999e+03 -9.999e+03</span></div><div class='xr-array-data'><pre>array([[-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "       [-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "       [-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "       ...,\n",
        "       [-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "       [-9999., -9999., -9999., ..., -9999., -9999., -9999.],\n",
        "       [-9999., -9999., -9999., ..., -9999., -9999., -9999.]],\n",
-       "      dtype=float32)</pre></div></div></li><li class='xr-section-item'><input id='section-3d96ac6c-621f-45cc-aa42-f7452d7f9ed9' class='xr-section-summary-in' type='checkbox'  checked><label for='section-3d96ac6c-621f-45cc-aa42-f7452d7f9ed9' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>era</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>1</div><input id='attrs-7fe6e4fe-6d81-4dc2-bc0a-44dbfb83143f' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7fe6e4fe-6d81-4dc2-bc0a-44dbfb83143f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4159b86e-3666-4667-b8e9-a9e57a906e32' class='xr-var-data-in' type='checkbox'><label for='data-4159b86e-3666-4667-b8e9-a9e57a906e32' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(1)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>model</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>2</div><input id='attrs-81e9925d-32ad-4e50-b5ce-932ef31992a2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-81e9925d-32ad-4e50-b5ce-932ef31992a2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1a2057e5-b507-4fbb-bb18-3e2177aacb92' class='xr-var-data-in' type='checkbox'><label for='data-1a2057e5-b507-4fbb-bb18-3e2177aacb92' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(2)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>scenario</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>1</div><input id='attrs-3f01700f-ff18-43eb-a357-ff224809fde5' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-3f01700f-ff18-43eb-a357-ff224809fde5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0c0901d1-c3f5-407a-bb33-83e9527bac54' class='xr-var-data-in' type='checkbox'><label for='data-0c0901d1-c3f5-407a-bb33-83e9527bac54' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(1)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.373e+06 2.369e+06 ... 4.214e+05</div><input id='attrs-5478d2bf-d7b8-46f8-8eb8-12696b6c0d0a' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-5478d2bf-d7b8-46f8-8eb8-12696b6c0d0a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-994bbe08-ed6e-42a7-90d1-7e95077ff717' class='xr-var-data-in' type='checkbox'><label for='data-994bbe08-ed6e-42a7-90d1-7e95077ff717' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2373412.93264, 2369412.93264, 2365412.93264, ...,  429412.93264,\n",
-       "        425412.93264,  421412.93264])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-2.164e+06 -2.16e+06 ... 1.488e+06</div><input id='attrs-268b98bf-4c20-4229-991b-b54fa90d2777' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-268b98bf-4c20-4229-991b-b54fa90d2777' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e6551e55-d502-4191-aff5-00e649235463' class='xr-var-data-in' type='checkbox'><label for='data-e6551e55-d502-4191-aff5-00e649235463' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-2164223.20581, -2160223.20581, -2156223.20581, ...,  1479776.79419,\n",
-       "        1483776.79419,  1487776.79419])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-e56b0bb5-5f85-400c-8884-96e57456ee4c' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-e56b0bb5-5f85-400c-8884-96e57456ee4c' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "      dtype=float32)</pre></div></div></li><li class='xr-section-item'><input id='section-bb9a6ff8-2429-4709-9b5a-b97a4783bd83' class='xr-section-summary-in' type='checkbox'  checked><label for='section-bb9a6ff8-2429-4709-9b5a-b97a4783bd83' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>era</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>1</div><input id='attrs-cee92849-140a-4d97-9ca6-92948e182801' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-cee92849-140a-4d97-9ca6-92948e182801' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-96333c0e-6138-4ff7-87af-152b5c39e271' class='xr-var-data-in' type='checkbox'><label for='data-96333c0e-6138-4ff7-87af-152b5c39e271' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(1)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>model</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>2</div><input id='attrs-ab8072b0-dcca-42c3-9419-c9ebedbee55b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-ab8072b0-dcca-42c3-9419-c9ebedbee55b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-71f985c2-e9a8-4ffb-bda5-72b001320eb7' class='xr-var-data-in' type='checkbox'><label for='data-71f985c2-e9a8-4ffb-bda5-72b001320eb7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(2)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>scenario</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>1</div><input id='attrs-64110a45-e7b7-4e0b-b9f8-f4a01362a6e3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-64110a45-e7b7-4e0b-b9f8-f4a01362a6e3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2f756077-3e52-4ee2-bc39-fec9e2d81fb2' class='xr-var-data-in' type='checkbox'><label for='data-2f756077-3e52-4ee2-bc39-fec9e2d81fb2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(1)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.373e+06 2.369e+06 ... 4.214e+05</div><input id='attrs-fd513c89-b5e4-4887-8994-c9f2c8b1a3e4' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-fd513c89-b5e4-4887-8994-c9f2c8b1a3e4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-99649999-511f-412b-bbff-aadac8635d20' class='xr-var-data-in' type='checkbox'><label for='data-99649999-511f-412b-bbff-aadac8635d20' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2373412.93264, 2369412.93264, 2365412.93264, ...,  429412.93264,\n",
+       "        425412.93264,  421412.93264])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-2.164e+06 -2.16e+06 ... 1.488e+06</div><input id='attrs-9726b1c1-f8f0-4590-a2fc-d6bbe4499afe' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9726b1c1-f8f0-4590-a2fc-d6bbe4499afe' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0b3fceb0-f733-4474-be3c-d51e6d5fdc3e' class='xr-var-data-in' type='checkbox'><label for='data-0b3fceb0-f733-4474-be3c-d51e6d5fdc3e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-2164223.20581, -2160223.20581, -2156223.20581, ...,  1479776.79419,\n",
+       "        1483776.79419,  1487776.79419])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1fe163cb-ed3d-4c1c-a194-3db3e28fb3ad' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-1fe163cb-ed3d-4c1c-a194-3db3e28fb3ad' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'alt' (y: 489, x: 914)>\n",
@@ -1990,7 +1995,7 @@
        "  * x         (x) float64 -2.164e+06 -2.16e+06 ... 1.484e+06 1.488e+06"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2001,7 +2006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 26,
    "id": "188cbf81",
    "metadata": {},
    "outputs": [
@@ -2023,7 +2028,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 27,
    "id": "38831b42",
    "metadata": {},
    "outputs": [
@@ -2050,7 +2055,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 28,
    "id": "e6b2e337",
    "metadata": {},
    "outputs": [
@@ -2060,7 +2065,7 @@
        "True"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2071,7 +2076,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 29,
    "id": "3b1ed972",
    "metadata": {},
    "outputs": [],
@@ -2084,7 +2089,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 30,
    "id": "47a4cd4e",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
This PR accomplishes two things:

1.) Fixes an error where the `magt` data were labeled as `alt` and vice-versa for the historical baseline. The error was caused in the preprocessing of the data when converting from .asc data to GeoTIFF. This was rectified in the preprocessing Jupyter notebook. Data were re-processed and successfully ingested to the dev Rasdaman instance on Apollo.

2.) Adds a dictionary of "encodings" to the metadata that map the numerical axis identifiers used in the netCDF (0, 1, 2, etc.) that are necessary for the Rasdaman ingest. I did this because it could be a handy way for endpoints to access and query the data vs. manually reproducing some version in a `luts.py` or similar in an API endpoint. When you request the data, you also get what you need to parse it back into something useful or at least human-readable.

You can see those encodings via PetaScope in the "Coverage Metadata" drop-down:

![image](https://user-images.githubusercontent.com/7774271/148612045-b3858466-d390-4ee5-a674-3adf28da8b93.png)
