### PR TITLE
Arctic eds annual precip

### DIFF
--- a/arctic_eds/annual_mean_pr/hook_ingest.json
+++ b/arctic_eds/annual_mean_pr/hook_ingest.json
@@ -1,0 +1,83 @@
+{
+  "config": {
+    "service_url": "http://localhost:8080/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "blocking": true,
+    "mock": false,
+    "automated": true,
+    "track_files": false
+  },
+  "input": {
+    "coverage_id": "annual_precip_totals",
+    "paths": [
+      "geotiffs/*.tif"
+    ]
+  },
+  "recipe": {
+    "name": "general_coverage",
+    "options": {
+      "wms_import": true,
+      "coverage": {
+        "crs": "OGC/0/Index1D?axis-label=\"model\"@OGC/0/Index1D?axis-label=\"scenario\"@OGC/0/AnsiDate?axis-label=\"year\"@EPSG/0/3338",
+        "metadata": {
+          "type": "xml",
+          "global": {
+            "Title": "",
+            "Encoding": {
+              "model": {
+                "1": "CRU-TS",
+                "2": "GFDL-CM3",
+                "3": "GISS-E2-R",
+                "4": "IPSL-CM5A-LR",
+                "0": "5modelAvg",
+                "5": "MRI-CGCM3",
+                "6": "NCAR-CCSM4"
+              },
+              "scenario": {
+                "0": "historical",
+                "1": "rcp45",
+                "2": "rcp60",
+                "3": "rcp85"
+              }
+            }
+          }
+        },
+        "slicer": {
+          "type": "gdal",
+          "axes": {
+            "model": {
+              "statements": "import imp, os; luts = imp.load_source('luts', os.getenv('LUTS_PATH')); regex_str = 'pr_(MRI-CGCM3|CRU-TS|NCAR-CCSM4|5modelAvg|GISS-E2-R|IPSL-CM5A-LR|GFDL-CM3)_(.*?)_([0-9]{4}).tif'",
+              "min": "luts.models[regex_extract('${file:name}', regex_str, 1)]",
+              "irregular": true,
+              "dataBound": false
+            },
+            "scenario": {
+              "min": "luts.scenarios[regex_extract('${file:name}', regex_str, 2)]",
+              "irregular": true,
+              "dataBound": false
+            },
+            "year": {
+              "min": "datetime(regex_extract('${file:name}', regex_str , 3), 'YYYY')",
+              "crsOrder": 0,
+              "gridOrder": 0,
+              "type": "ansidate",
+              "irregular": true,
+              "sliceGroupSize": 1,
+              "dataBound": false
+            },
+            "X": {
+              "min": "${gdal:minX}",
+              "max": "${gdal:maxX}",
+              "resolution": "${gdal:resolutionX}"
+            },
+            "Y": {
+              "min": "${gdal:minY}",
+              "max": "${gdal:maxY}",
+              "resolution": "${gdal:resolutionY}"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/arctic_eds/annual_mean_pr/luts.py
+++ b/arctic_eds/annual_mean_pr/luts.py
@@ -1,0 +1,16 @@
+models = {
+    "5modelAvg": 0,
+    "CRU-TS": 1,
+    "GFDL-CM3": 2,
+    "GISS-E2-R": 3,
+    "IPSL-CM5A-LR": 4,
+    "MRI-CGCM3": 5,
+    "NCAR-CCSM4": 6,
+}
+
+scenarios = {
+    "historical": 0,
+    "rcp45": 1,
+    "rcp60": 2,
+    "rcp85": 3,
+}


### PR DESCRIPTION
This PR contains a preprocessing notebook and ingest recipe for a new annual_precip coverage to supply the data for the forthcoming "Mean Annual Precipitation" plate of the Arctic EDS.

This coverage contains historical and projected annual precipitation totals data derived from SNAP downscaled CRU-TS40 and CMIP5 datasets. No styles are tracked here at this time. This coverage has not yet been implemented on Zeus. Copies of the necessary ingest data exist on Atlas at `/atlas_scratch/cparr4/rasdaman_prod`

(Note, the coverage is called annual_precip, as the data are just annual totals and not means)