### PR TITLE
use native mm instead of inches

### DIFF
--- a/arctic_eds/annual_mean_snowfall/hook_ingest.json
+++ b/arctic_eds/annual_mean_snowfall/hook_ingest.json
@@ -8,12 +8,13 @@
     "track_files": false
   },
   "hooks": [
-  {
-    "description": "Create WMS Style for Layer",
-    "when": "after_import",
-    "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=mean_annual_snowfall_mm&STYLEID=snowfall_mm&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0], \\\"0\\\": [237, 248, 251, 255], \\\"50\\\": [191, 211, 230, 255], \\\"100\\\": [158, 188, 218, 255], \\\"500\\\": [140, 150, 198, 255], \\\"1000\\\": [140, 107, 177, 167], \\\"2000\\\": [136, 65, 167, 255], \\\"3000\\\": [110, 1, 107, 255] } }\"",
-    "abort_on_error": true
-  },
+    {
+      "description": "Create WMS Style for Layer",
+      "when": "after_import",
+      "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=mean_annual_snowfall_mm&STYLEID=snowfall_mm&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0], \\\"0\\\": [237, 248, 251, 255], \\\"50\\\": [191, 211, 230, 255], \\\"100\\\": [158, 188, 218, 255], \\\"500\\\": [140, 150, 198, 255], \\\"1000\\\": [140, 107, 177, 167], \\\"2000\\\": [136, 65, 167, 255], \\\"3000\\\": [110, 1, 107, 255] } }\"",
+      "abort_on_error": true
+    }
+  ],
   "input": {
     "coverage_id": "mean_annual_snowfall_mm",
     "paths": [

--- a/arctic_eds/annual_mean_snowfall/hook_ingest.json
+++ b/arctic_eds/annual_mean_snowfall/hook_ingest.json
@@ -7,6 +7,13 @@
     "automated": true,
     "track_files": false
   },
+  "hooks": [
+  {
+    "description": "Create WMS Style for Layer",
+    "when": "after_import",
+    "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=mean_annual_snowfall_mm&STYLEID=snowfall_mm&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0], \\\"0\\\": [237, 248, 251, 255], \\\"50\\\": [191, 211, 230, 255], \\\"100\\\": [158, 188, 218, 255], \\\"500\\\": [140, 150, 198, 255], \\\"1000\\\": [140, 107, 177, 167], \\\"2000\\\": [136, 65, 167, 255], \\\"3000\\\": [110, 1, 107, 255] } }\"",
+    "abort_on_error": true
+  },
   "input": {
     "coverage_id": "mean_annual_snowfall_mm",
     "paths": [

--- a/arctic_eds/annual_mean_snowfall/hook_ingest.json
+++ b/arctic_eds/annual_mean_snowfall/hook_ingest.json
@@ -8,7 +8,7 @@
     "track_files": false
   },
   "input": {
-    "coverage_id": "mean_annual_snowfall",
+    "coverage_id": "mean_annual_snowfall_mm",
     "paths": [
       "geotiffs/*.tif"
     ]


### PR DESCRIPTION
This PR represents a reprocessing and re-ingest of the snowfall data that drive the snowfall plate in the Arctic-EDS. The motivation was to serve SI units over the API and to do some validation to be sure that the numbers coming out of the client and the API match the values directly extracted from the GeoTIFF sources. It may be hard to see the diffs in the processing notebook, but the key changes are:

 - I’ve changed the GeoTIFF format to float32 from Int16
 - I’ve removed the code snippet that converted from mm to inches.
 - I extracted the min-max-mean historical and projected values for Fairbanks, Anchorage, (using GVV coordinates) and the example lat-lon used in the API documentation. These values can easily be referenced as changes are made to the Arctic-EDS client.

Notes
 - these data are ingested as 'mean_annual_snowfall_mm' on Apollo
 - the API has already been updated to reflect the changes in this PR
 - XREF #34 
 - XREF https://github.com/ua-snap/data-api/pull/200
 - XREF https://github.com/ua-snap/arctic-eds/pull/73
 - Closes #35