### PR TITLE
Covert Arctic-EDS Annual Precip coverage to mm with no decimals.

### DIFF
--- a/arctic_eds/annual_mean_pr/hook_ingest.json
+++ b/arctic_eds/annual_mean_pr/hook_ingest.json
@@ -11,7 +11,7 @@
     {
       "description": "Create Style for WMS Layer",
       "when": "after_import",
-      "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=annual_precip_totals_mm&STYLEID=precip_mm&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0], \\\"0\\\": [140,81,10, 255], \\\"250\\\": [216,179,101, 255], \\\"500\\\": [246,232,195, 255], \\\"1200\\\": [245,245,245, 255], \\\"2500\\\": [199,234,229, 255], \\\"5000\\\": [90,180,172, 255], \\\"10000\\\": [1,102,94, 255] } }\"",
+      "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=annual_precip_totals_mm&STYLEID=precip_mm&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0], \\\"0\\\": [140,81,10, 255], \\\"250\\\": [216,179,101, 255], \\\"500\\\": [246,232,195, 255], \\\"1200\\\": [245,245,245, 255], \\\"2500\\\": [199,234,229, 255], \\\"5000\\\": [90,180,172, 255], \\\"10000\\\": [1,102,94, 255] } }\"",
       "abort_on_error": true
     }
   ],


### PR DESCRIPTION
This PR represents a re-processing and re-ingest of the data for the Arctic-EDS Precipitation Plate.

The key changes include:
 - removal of the code snippet that converts from mm to inches
 - retaining a `float32` GeoTIFF type
 - extracting some data at a few select locations to compare against API and client outputs
 - establishing a new style for the mm units, and adding the style hook to the ingest

The coverage is available on Apollo: `annual_precip_totals_mm`

The notebook does not need to run, but it should be given a once over in review.

Closes #37 
Closes #34

XREF https://github.com/ua-snap/data-api/pull/201