### PR TITLE
Ingest most recent GIPL outputs

### DIFF
--- a/ardac/gipl/ingest.json
+++ b/ardac/gipl/ingest.json
@@ -1,0 +1,110 @@
+{
+  "config": {
+    "service_url": "http://localhost:8080/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "blocking": true,
+    "mock": false,
+    "automated": true,
+    "track_files": false
+  },
+  "hooks": [
+    {
+      "description": "Create GIPL Mean Annual Ground Temperature Style for the Arctic-EDS.",
+      "when": "after_import",
+      "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=crrel_gipl_outputs&STYLEID=arctic_eds_gipl_ground_temp&ABSTRACT=Average%20of%20years%20from%202040-2069&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2861%3A90%29%20using%20%24c.magt1m%5Byear%28%24t%29%2C%20model%282%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
+        \\\"-20\\\": [33, 102, 172, 255],
+        \\\"-6\\\": [67, 147, 195, 255],
+        \\\"-4\\\": [146, 197, 222, 255],
+        \\\"-2\\\": [209, 229, 240, 255],
+        \\\"-1\\\": [247, 247, 247, 255],
+        \\\"-0\\\": [253, 219, 199, 255],
+        \\\"1\\\": [244, 165, 130, 255],
+        \\\"2\\\": [214, 96, 77, 255] } }\"",
+      "abort_on_error": true
+   }
+  ],
+  "input": {
+    "coverage_id": "crrel_gipl_outputs",
+    "paths": [
+      "geotiffs/*.tif"
+    ]
+  },
+  "recipe": {
+    "name": "general_coverage",
+    "options": {
+      "wms_import": true,
+      "coverage": {
+        "crs": "OGC/0/Index1D?axis-label=\"model\"@OGC/0/Index1D?axis-label=\"scenario\"@OGC/0/Index1D?axis-label=\"variable\"@OGC/0/AnsiDate?axis-label=\"year\"@EPSG/0/3338",
+        "metadata": {
+          "type": "xml",
+          "global": {
+            "Title": "",
+            "Encoding": {
+              "model": {
+                "0": "5ModelAvg",
+                "1": "GFDL-CM3",
+                "2": "NCAR-CCSM4"
+              },
+              "scenario": {
+                "0": "RCP 4.5",
+                "1": "RCP 8.5"
+              },
+              "variable": {
+                "0": "magt0.5m",
+                "1": "magt1m",
+                "2": "magt2m",
+                "3": "magt3m",
+                "4": "magt4m",
+                "5": "magt5m",
+                "6": "magtsurface",
+                "7": "permafrostbase",
+                "8": "permafrosttop",
+                "9": "talikthickness"
+              }
+            }
+          }
+        },
+        "slicer": {
+          "type": "gdal",
+          "axes": {
+            "model": {
+              "statements": "import imp, os; luts = imp.load_source('luts', os.getenv('LUTS_PATH')); regex_str = 'gipl_(5ModelAvg|NCAR-CCSM4|GFDL-CM3)_(rcp45|rcp85)_(magt1m|magt3m|talikthickness|magt5m|magtsurface|permafrostbase|magt4m|magt2m|permafrosttop|magt0.5m)_(degC|m)_([0-9]{4}).tif'",
+              "min": "luts.models[regex_extract('${file:name}', regex_str, 1)]",
+              "irregular": true,
+              "dataBound": false
+            },
+            "scenario": {
+              "min": "luts.scenarios[regex_extract('${file:name}', regex_str, 2)]",
+              "irregular": true,
+              "dataBound": false
+            },
+            "variable": {
+              "min": "luts.pf_variables[regex_extract('${file:name}', regex_str, 3)]",
+              "irregular": true,
+              "dataBound": false
+            },
+            "year": {
+              "min": "datetime(regex_extract('${file:name}', regex_str , 5), 'YYYY')",
+              "crsOrder": 0,
+              "gridOrder": 0,
+              "type": "ansidate",
+              "irregular": true,
+              "sliceGroupSize": 1,
+              "dataBound": false
+            },
+            "X": {
+              "min": "${gdal:minX}",
+              "max": "${gdal:maxX}",
+              "resolution": "${gdal:resolutionX}"
+            },
+            "Y": {
+              "min": "${gdal:minY}",
+              "max": "${gdal:maxY}",
+              "resolution": "${gdal:resolutionY}"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ardac/gipl/luts.py
+++ b/ardac/gipl/luts.py
@@ -1,0 +1,23 @@
+models = {
+    "5ModelAvg": 0,
+    "GFDL-CM3": 1,
+    "NCAR-CCSM4": 2,
+}
+
+scenarios = {
+    "rcp45": 0,
+    "rcp85": 1,
+}
+
+pf_variables = {
+    "magt0.5m": 0,
+    "magt1m": 1,
+    "magt2m": 2,
+    "magt3m": 3,
+    "magt4m": 4,
+    "magt5m": 5,
+    "magtsurface": 6,
+    "permafrostbase": 7,
+    "permafrosttop": 8,
+    "talikthickness": 9,
+}


### PR DESCRIPTION
This PR contains the ingest recipe for the full suite of the most recent GIPL model outputs. These data are comprised of 6000 GeoTIFFs (1 km spatial resolution) that account for the following datacube axes:

- Climate Model
  - 5-Model Average
  - GFDL-CM3
  - NCAR-CCSM4
- Emissions Scenario
  - RCP 4.5
  - RCP 8.5
- Permafrost Variable
  - Mean Annual Ground Temperature (surface)
  - Mean Annual Ground Temperature (0.5 m depth)
  - Mean Annual Ground Temperature (1 m depth)
  - Mean Annual Ground Temperature (2 m depth)
  - Mean Annual Ground Temperature (3 m depth)
  - Mean Annual Ground Temperature (4 m depth)
  - Mean Annual Ground Temperature (5 m depth)
  - Permafrost Top (depth in m)
  - Permafrost Base (depth in m)
  - Talik Thickness (m)
  
This dataset does not contain historical data.

 To test this PR, edit the ingest recipe to create a dummy coverage ID (e.g., `foo_gipl`) and set the look-up, e.g., `export LUTS_PATH=/home/UA/cparr4/rasdaman_tmp/gipl/luts.py`

The data should be in a directory called `geotiffs` that is at the same directory level as the ingest recipe. These data are still on Apollo (`/home/UA/cparr4/rasdaman_tmp/gipl`) but are also archived at `/workspace/Shared/Tech_Projects/Arctic_EDS/project_data/rasdaman_datasets/crrel_gipl_outputs` so you can grab all 6000 GeoTIFFs which will make for quite a long ingest, or a representative sample like two individual GeoTIFFS for each of the conditions bulleted above.

Note
 - The full ingest might stutter. With a few of the larger ingests, we've seen a behavior where the ingest fails, we delete the coverage, change nothing else, try again, and the ingest works. If you fail at an odd spot, try again.
 - The styles here are not complete. We'll need to continue adding styles once we decide what variables are most desirable for maps in client apps.
 - This PR is ingest recipe only - all the pre-processing, QA, etc. is in the [ardac-curation](https://github.com/ua-snap/ardac-curation) repo.