### PR TITLE
add beetle style as ingest hook

### DIFF
--- a/beetles/ingest.json
+++ b/beetles/ingest.json
@@ -14,7 +14,7 @@
   },
   "hooks": [
     {
-      "description": "Create beetlke risk class style for WMS Layer",
+      "description": "Create beetle risk class style for WMS Layer",
       "when": "after_import",
       "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=beetle_risk&STYLEID=beetle_risk&ABSTRACT=Beetle%20risk&WCPSQUERYFRAGMENT=%24c&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"values\\\", \\\"colorTable\\\": {  \\\"0\\\": [0, 0, 0, 0],
        \\\"0\\\": [0, 0, 0, 0],

--- a/beetles/ingest.json
+++ b/beetles/ingest.json
@@ -12,6 +12,18 @@
       "risk_class/*.tif"
     ]
   },
+  "hooks": [
+    {
+      "description": "Create beetlke risk class style for WMS Layer",
+      "when": "after_import",
+      "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=beetle_risk&STYLEID=beetle_risk&ABSTRACT=Beetle%20risk&WCPSQUERYFRAGMENT=%24c&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"values\\\", \\\"colorTable\\\": {  \\\"0\\\": [0, 0, 0, 0],
+       \\\"0\\\": [0, 0, 0, 0],
+       \\\"1\\\": [0, 128, 0, 255],
+       \\\"2\\\": [247, 189, 0, 255],
+       \\\"3\\\": [121, 92, 52, 55] } }\"",
+      "abort_on_error": true
+    }
+  ],
   "recipe": {
     "name": "general_coverage",
     "options": {


### PR DESCRIPTION
Adds a hook for the preexisting style for the beetle risk coverage to the ingest file. You can test using the dataset in the `Tech_Projects/rasdaman_production_datasets` (also already in `/home/UA/kmredilla/rasdaman_tmp/beetles/risk_class` on Apollo).