### PR TITLE
Update beetle risk color map to new color blind friendly version

### DIFF
--- a/beetles/ingest.json
+++ b/beetles/ingest.json
@@ -17,10 +17,9 @@
       "description": "Create beetle risk class style for WMS Layer",
       "when": "after_import",
       "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=beetle_risk&STYLEID=beetle_risk&ABSTRACT=Beetle%20risk&WCPSQUERYFRAGMENT=%24c&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"values\\\", \\\"colorTable\\\": {  \\\"0\\\": [0, 0, 0, 0],
-       \\\"0\\\": [0, 0, 0, 0],
-       \\\"1\\\": [0, 128, 0, 255],
-       \\\"2\\\": [247, 189, 0, 255],
-       \\\"3\\\": [121, 92, 52, 55] } }\"",
+       \\\"1\\\": [0, 184, 0, 255],
+       \\\"2\\\": [255, 239, 10, 255],
+       \\\"3\\\": [251, 47, 24, 255] } }\"",
       "abort_on_error": true
     }
   ],


### PR DESCRIPTION
Xref: https://github.com/ua-snap/iem-webapp/issues/452

This PR simply updates the color scheme for the beetle risk color map, but also removes a redundant color entry for the 0 value.