### PR TITLE
Degree Days dataset SNAP portal prep

### DIFF
--- a/arctic_eds/degree_days/portal_prep.ipynb
+++ b/arctic_eds/degree_days/portal_prep.ipynb
@@ -1,0 +1,363 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "44b3698c-6075-464e-aff1-c67319c66fbe",
+   "metadata": {},
+   "source": [
+    "# Prepping Degree Days dataset for hosting\n",
+    "\n",
+    "This notebook captures information from the degree days dataset for generating a standard metadata / GeoNetwork entry, and creates helpful `.zip`s. This dataset consists of the freezing index, thawing index, degree days below zero, and heating degree days. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "id": "5ef95df6-70a2-42c5-a611-5bfa8ed16a18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import calendar\n",
+    "\n",
+    "import os\n",
+    "import subprocess\n",
+    "from pathlib import Path\n",
+    "# from subprocess import call\n",
+    "# import matplotlib.pyplot as plt\n",
+    "# import numpy as np\n",
+    "# import xarray as xr\n",
+    "# import rasterio as rio\n",
+    "from itertools import product\n",
+    "# from tqdm.contrib.concurrent import process_map\n",
+    "import rasterio as rio\n",
+    "from rasterio.warp import transform_bounds\n",
+    "import numpy as np\n",
+    "\n",
+    "archive_path = Path(os.getenv(\"ARCHIVE_DIR\") or \"/workspace/Shared/Tech_Projects/Arctic_EDS/project_data/rasdaman_datasets/\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10fa6b10-8cd3-4792-a478-26296a0b544b",
+   "metadata": {},
+   "source": [
+    "### Spatial info: extent in WGS84, resolution, dimensions\n",
+    "\n",
+    "Get the spatial extent of this dataset in WGS84 (and use as an opportunity to ensure they are all the same)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88b72816-90d3-4a92-851d-f88ea2ccbcfc",
+   "metadata": {},
+   "source": [
+    "Use a [function](https://github.com/ua-snap/snap-geo/blob/e65e2d9aee0a1a0ea8c3432b3d01807476316206/antimeridian_raster_bbox.ipynb) to get WGS84 extent when the west side crosses the dateline. Adapt it to pull the resolution and spatial dimension sizes as well. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "8d1fdc0b-a0bc-4677-ad82-064efc9297f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_wgs84_extent(gtiff_fp):\n",
+    "    with rio.open(gtiff_fp) as src:\n",
+    "        src_crs = src.crs\n",
+    "        src_bounds = src.bounds\n",
+    "        x_res = src.transform[0]\n",
+    "        y_res = -src.transform[4]\n",
+    "        width, height = src.width, src.height\n",
+    "    dst_crs = CRS.from_wkt(\n",
+    "        CRS.from_epsg(4326).to_wkt().replace('PRIMEM[\"Greenwich\",0', 'PRIMEM[\"Greenwich\",180')\n",
+    "    )\n",
+    "    bounds = transform_bounds(src_crs, dst_crs, *src_bounds)\n",
+    "    new_bounds = np.round((bounds[0] - 180, bounds[1], bounds[2] - 180, bounds[3]), 4)\n",
+    "    \n",
+    "    return new_bounds, x_res, y_res, width, height"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "8a9cf213-f3d0-4196-a79b-bf11c4ecb0cc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 8.13 s, sys: 671 ms, total: 8.8 s\n",
+      "Wall time: 9.64 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "dd_types = [\"thawing_index\", \"heating_degree_days\", \"freezing_index\", \"degree_days_below_zero\"]\n",
+    "all_bounds = []\n",
+    "x_sizes, y_sizes = [], []\n",
+    "widths, heights = [], []\n",
+    "for dd_name in dd_types:\n",
+    "    fps = list(archive_path.joinpath(dd_name).glob(\"*.tif\"))\n",
+    "    out = [get_wgs84_extent(fp) for fp in fps]\n",
+    "    all_bounds.extend([o[0] for o in out])\n",
+    "    x_sizes.extend([o[1] for o in out])\n",
+    "    y_sizes.extend([o[2] for o in out])\n",
+    "    widths.extend([o[3] for o in out])\n",
+    "    heights.extend([o[4] for o in out])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22ac7d49-5726-4a76-9ad4-604393092c87",
+   "metadata": {},
+   "source": [
+    "If the below cell executes without error, then all files have the same extent:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "236ab2f5-79a8-415b-a2e5-4767d67897f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert np.all([all_bounds[0] == bnds for bnds in all_bounds])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84eab4f7-369b-4535-bb9b-84c18e2e518d",
+   "metadata": {},
+   "source": [
+    "View the bounds for inclusion in metadata:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "0c4f799e-4ce3-40ba-96d2-bffc965329a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WSEN bounds: [-202.4147   49.1771 -117.4109   71.3851]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"WSEN bounds:\", all_bounds[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "220b5428-d53d-48a5-b1c7-5eef0a3598ce",
+   "metadata": {},
+   "source": [
+    "Likewise, confirm that all files have the same X and Y sizes, and print those sizes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "453bb74c-9033-49e0-8d66-79df2fc99e86",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X resolution: 18485.55530202021\n",
+      "Y resolution: 18493.020445282968\n"
+     ]
+    }
+   ],
+   "source": [
+    "assert np.all([x_sizes[0] == res for res in x_sizes])\n",
+    "assert np.all([y_sizes[0] == res for res in y_sizes])\n",
+    "print(\"X resolution:\", x_sizes[0])\n",
+    "print(\"Y resolution:\", y_sizes[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87903fd5-a1f2-46bb-b7ad-c0efe2581baa",
+   "metadata": {},
+   "source": [
+    "Confirm that all files have the same shape, and print those:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "c6cbf175-b255-4459-a1d9-a08644e9304d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X dimension size: 198\n",
+      "Y dimension size: 106\n"
+     ]
+    }
+   ],
+   "source": [
+    "assert np.all([widths[0] == w for w in widths])\n",
+    "assert np.all([heights[0] == h for h in heights])\n",
+    "print(\"X dimension size:\", widths[0])\n",
+    "print(\"Y dimension size:\", heights[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8c993dc-f0bf-4fbe-aa5f-51f83ac41081",
+   "metadata": {},
+   "source": [
+    "### Temporal extent\n",
+    "\n",
+    "Confirm that there is a file for each and every year from 1980-2100, as expected based on [processing notebook](./dd_preprocessing.ipynb), for all degree day types:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "a94e2cd6-51cc-450c-ae91-725f0e4d989c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gcms = [\"GFDL-CM3\", \"NCAR-CCSM4\"]\n",
+    "gcm_years = np.arange(2006, 2101)\n",
+    "era_years = np.arange(1980, 2009)\n",
+    "files_exist = []\n",
+    "for dd_name in dd_types:\n",
+    "    for gcm in gcms:\n",
+    "        files_exist.extend(\n",
+    "            [\n",
+    "                Path(archive_path.joinpath(dd_name, f\"{dd_name}_{gcm}_{year}.tif\")).exists()\n",
+    "                for year in gcm_years    \n",
+    "            ]\n",
+    "        )\n",
+    "        files_exist.extend(\n",
+    "            [\n",
+    "                Path(archive_path.joinpath(dd_name, f\"{dd_name}_ERA-Interim_{year}.tif\")).exists()\n",
+    "                for year in era_years    \n",
+    "            ]\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb66320f-cbf7-44c2-8f17-254d32f1f61a",
+   "metadata": {},
+   "source": [
+    "If this cell executes without error, then all years and models are accounted for:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "49d22b6e-b197-4fcd-94c5-7031c2a478be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert np.all(files_exist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d9b5423-e7c6-47b3-a1e9-2d9e7df830f6",
+   "metadata": {},
+   "source": [
+    "## Zip files for distribution\n",
+    "\n",
+    "Here we will zip the files for distribution. We will zip them by degree day variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "id": "5f528fb8-83bc-4aca-a356-5a0bfa4d5f00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zip_dir = archive_path.parent.joinpath(\"dd_zips\")\n",
+    "zip_dir.mkdir(exist_ok=True)\n",
+    "\n",
+    "for dd_name in dd_types:\n",
+    "    command = f\"bash ./zipit.sh {archive_path} {dd_name} {zip_dir}\"\n",
+    "    output = subprocess.check_output(command, shell=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d9f2f16-ef53-4386-a6d5-a97178f89f57",
+   "metadata": {},
+   "source": [
+    "Did we zip them all?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "id": "5dba6135-b3a8-48ce-97b0-64d77cd3de11",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PosixPath('/workspace/Shared/Tech_Projects/Arctic_EDS/project_data/dd_zips/thawing_index.zip'),\n",
+       " PosixPath('/workspace/Shared/Tech_Projects/Arctic_EDS/project_data/dd_zips/heating_degree_days.zip'),\n",
+       " PosixPath('/workspace/Shared/Tech_Projects/Arctic_EDS/project_data/dd_zips/freezing_index.zip'),\n",
+       " PosixPath('/workspace/Shared/Tech_Projects/Arctic_EDS/project_data/dd_zips/degree_days_below_zero.zip')]"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# did we zip 'em all?\n",
+    "zips = list(zip_dir.glob(\"*.zip\"))\n",
+    "zips"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbd63670-0484-400d-b5d8-0291a0272575",
+   "metadata": {},
+   "source": [
+    "Looks like it. Make a directory in Poseidon and link these files (/workspace/CKAN not available on compute node):\n",
+    "\n",
+    "```\n",
+    "cp /workspace/Shared/Tech_Projects/Arctic_EDS/project_data/dd_zips/*.zip /workspace/CKAN/CKAN_Data/Base/AK_WRF/Arctic_EDS_degree_days\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/arctic_eds/degree_days/portal_prep.ipynb
+++ b/arctic_eds/degree_days/portal_prep.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 1,
    "id": "5ef95df6-70a2-42c5-a611-5bfa8ed16a18",
    "metadata": {},
    "outputs": [],
@@ -22,6 +22,7 @@
     "from pathlib import Path\n",
     "import rasterio as rio\n",
     "from rasterio.warp import transform_bounds\n",
+    "from rasterio.crs import CRS \n",
     "import numpy as np\n",
     "\n",
     "archive_path = Path(os.getenv(\"ARCHIVE_DIR\") or \"/workspace/Shared/Tech_Projects/Arctic_EDS/project_data/rasdaman_datasets/\")"
@@ -47,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 2,
    "id": "8d1fdc0b-a0bc-4677-ad82-064efc9297f0",
    "metadata": {},
    "outputs": [],
@@ -78,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 3,
    "id": "8a9cf213-f3d0-4196-a79b-bf11c4ecb0cc",
    "metadata": {},
    "outputs": [
@@ -86,8 +87,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8.13 s, sys: 671 ms, total: 8.8 s\n",
-      "Wall time: 9.64 s\n"
+      "CPU times: user 11.5 s, sys: 539 ms, total: 12 s\n",
+      "Wall time: 21.7 s\n"
      ]
     }
    ],
@@ -117,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 4,
    "id": "236ab2f5-79a8-415b-a2e5-4767d67897f4",
    "metadata": {},
    "outputs": [],
@@ -135,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 5,
    "id": "0c4f799e-4ce3-40ba-96d2-bffc965329a0",
    "metadata": {},
    "outputs": [
@@ -161,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 6,
    "id": "453bb74c-9033-49e0-8d66-79df2fc99e86",
    "metadata": {},
    "outputs": [
@@ -191,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 7,
    "id": "c6cbf175-b255-4459-a1d9-a08644e9304d",
    "metadata": {},
    "outputs": [
@@ -223,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 8,
    "id": "a94e2cd6-51cc-450c-ae91-725f0e4d989c",
    "metadata": {},
    "outputs": [],
@@ -258,7 +259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 9,
    "id": "49d22b6e-b197-4fcd-94c5-7031c2a478be",
    "metadata": {},
    "outputs": [],
@@ -273,18 +274,17 @@
    "source": [
     "## Zip files for distribution\n",
     "\n",
-    "Here we will zip the files for distribution. We will zip them by degree day variable."
+    "Here we will zip the files for distribution. We will zip them by degree day variable. Specify the path to write these zips in the prompt below:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 10,
    "id": "5f528fb8-83bc-4aca-a356-5a0bfa4d5f00",
    "metadata": {},
    "outputs": [],
    "source": [
-    "zip_dir = archive_path.parent.joinpath(\"dd_zips\")\n",
-    "zip_dir.mkdir(exist_ok=True)\n",
+    "zip_dir = Path(input(\"Specify path to place zips in: \") or \".\")\n",
     "\n",
     "for dd_name in dd_types:\n",
     "    command = f\"bash ./zipit.sh {archive_path} {dd_name} {zip_dir}\"\n",
@@ -301,20 +301,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 11,
    "id": "5dba6135-b3a8-48ce-97b0-64d77cd3de11",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[PosixPath('/workspace/Shared/Tech_Projects/Arctic_EDS/project_data/dd_zips/thawing_index.zip'),\n",
-       " PosixPath('/workspace/Shared/Tech_Projects/Arctic_EDS/project_data/dd_zips/heating_degree_days.zip'),\n",
-       " PosixPath('/workspace/Shared/Tech_Projects/Arctic_EDS/project_data/dd_zips/freezing_index.zip'),\n",
-       " PosixPath('/workspace/Shared/Tech_Projects/Arctic_EDS/project_data/dd_zips/degree_days_below_zero.zip')]"
+       "[PosixPath('thawing_index.zip'),\n",
+       " PosixPath('heating_degree_days.zip'),\n",
+       " PosixPath('freezing_index.zip'),\n",
+       " PosixPath('degree_days_below_zero.zip')]"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -330,10 +330,11 @@
    "id": "cbd63670-0484-400d-b5d8-0291a0272575",
    "metadata": {},
    "source": [
-    "Looks like it. Make a directory in Poseidon and copy these files (/workspace/CKAN not available on compute node):\n",
+    "Looks like it. Copy these zips to the relevant spots on Poseidon for both storage and distribution:\n",
     "\n",
     "```\n",
-    "cp /workspace/Shared/Tech_Projects/Arctic_EDS/project_data/dd_zips/*.zip /workspace/CKAN/CKAN_Data/Base/AK_WRF/Arctic_EDS_degree_days\n",
+    "cp *.zip /workspace/Shared/Tech_Projects/Arctic_EDS/project_data/dd_zips/\n",
+    "cp *.zip /workspace/CKAN/CKAN_Data/Base/AK_WRF/Arctic_EDS_degree_days\n",
     "```"
    ]
   }

--- a/arctic_eds/degree_days/portal_prep.ipynb
+++ b/arctic_eds/degree_days/portal_prep.ipynb
@@ -5,9 +5,9 @@
    "id": "44b3698c-6075-464e-aff1-c67319c66fbe",
    "metadata": {},
    "source": [
-    "# Prepping Degree Days dataset for hosting\n",
+    "# Prepare Degree Days dataset for hosting\n",
     "\n",
-    "This notebook captures information from the degree days dataset for generating a standard metadata / GeoNetwork entry, and creates helpful `.zip`s. This dataset consists of the freezing index, thawing index, degree days below zero, and heating degree days. "
+    "This notebook captures information from the degree days dataset, generated with the [dd_preprocessing.ipynb](./dd_preprocessing.ipynb) notebook, for generating a standard metadata / GeoNetwork entry, and creates helpful `.zip`s. This dataset consists of the freezing index, thawing index, degree days below zero, and heating degree days. "
    ]
   },
   {
@@ -17,18 +17,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# import calendar\n",
-    "\n",
     "import os\n",
     "import subprocess\n",
     "from pathlib import Path\n",
-    "# from subprocess import call\n",
-    "# import matplotlib.pyplot as plt\n",
-    "# import numpy as np\n",
-    "# import xarray as xr\n",
-    "# import rasterio as rio\n",
-    "from itertools import product\n",
-    "# from tqdm.contrib.concurrent import process_map\n",
     "import rasterio as rio\n",
     "from rasterio.warp import transform_bounds\n",
     "import numpy as np\n",
@@ -75,6 +66,14 @@
     "    new_bounds = np.round((bounds[0] - 180, bounds[1], bounds[2] - 180, bounds[3]), 4)\n",
     "    \n",
     "    return new_bounds, x_res, y_res, width, height"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abc1de46-d540-49cd-b565-930e655d4545",
+   "metadata": {},
+   "source": [
+    "Iterate over all files in the dataset and extract the spatial info, appending to lists for verification of uniformity:"
    ]
   },
   {
@@ -131,7 +130,7 @@
    "id": "84eab4f7-369b-4535-bb9b-84c18e2e518d",
    "metadata": {},
    "source": [
-    "View the bounds for inclusion in metadata:"
+    "View those bounds for inclusion in metadata file:"
    ]
   },
   {
@@ -219,7 +218,7 @@
    "source": [
     "### Temporal extent\n",
     "\n",
-    "Confirm that there is a file for each and every year from 1980-2100, as expected based on [processing notebook](./dd_preprocessing.ipynb), for all degree day types:"
+    "Confirm that there is a file for each and every year from 1980-2100, as expected based on the [processing notebook](./dd_preprocessing.ipynb), for all degree day types:"
    ]
   },
   {
@@ -331,7 +330,7 @@
    "id": "cbd63670-0484-400d-b5d8-0291a0272575",
    "metadata": {},
    "source": [
-    "Looks like it. Make a directory in Poseidon and link these files (/workspace/CKAN not available on compute node):\n",
+    "Looks like it. Make a directory in Poseidon and copy these files (/workspace/CKAN not available on compute node):\n",
     "\n",
     "```\n",
     "cp /workspace/Shared/Tech_Projects/Arctic_EDS/project_data/dd_zips/*.zip /workspace/CKAN/CKAN_Data/Base/AK_WRF/Arctic_EDS_degree_days\n",

--- a/arctic_eds/degree_days/zipit.sh
+++ b/arctic_eds/degree_days/zipit.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+directory="$1"
+dd_name="$2"
+zip_directory="$3"
+
+zip_file="${zip_directory}/${dd_name}.zip"
+
+echo "Creating ${zip_file}"
+# delete zip archive if it exists already
+rm -f "${zip_file}"
+
+# create a zip file for the variable and add all tiffs with this string in their filename to the zip
+find "${directory}/${dd_name}" -name "*${dd_name}*.tif" -print0 | xargs -0 zip -j "${zip_file}"


### PR DESCRIPTION
This PR adds a single Jupyter notebook (`arctic_eds/degree_days/portal_prep.ipynb`) for extracting metadata from and zipping the degree days data (as generated in this folder; no design indices in this one) for hosting via the SNAP GeoNetwork data portal ([here](https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/3d4cc2e2-5cfb-4fed-b397-06854edb747f)). This also includes a `zipit.sh` script for helping to zip the data files. To review, feel free to just have a look without running, or run the whole notebook. Any feedback is welcome! No rush on this.