### PR TITLE
ALFRESCO veg type and flammability datasets SNAP portal prep

### DIFF
--- a/iem/alfresco/portal_prep.ipynb
+++ b/iem/alfresco/portal_prep.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "id": "5ef95df6-70a2-42c5-a611-5bfa8ed16a18",
    "metadata": {},
    "outputs": [],
@@ -25,8 +25,7 @@
     "from rasterio.warp import transform_bounds\n",
     "import numpy as np\n",
     "\n",
-    "data_dir = Path(\"/workspace/Shared/Tech_Projects/Alaska_IEM/project_data/NCR_ALFRESCO_datasets/\")\n",
-    "out_dir = Path(\"/workspace/Shared/Tech_Projects/Alaska_IEM/final_products/NCR_ALFRESCO_zips\")"
+    "data_dir = Path(\"/workspace/Shared/Tech_Projects/Alaska_IEM/project_data/NCR_ALFRESCO_datasets/\")"
    ]
   },
   {
@@ -49,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "8d1fdc0b-a0bc-4677-ad82-064efc9297f0",
    "metadata": {},
    "outputs": [],
@@ -80,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 3,
    "id": "8a9cf213-f3d0-4196-a79b-bf11c4ecb0cc",
    "metadata": {},
    "outputs": [
@@ -88,8 +87,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 5.32 s, sys: 276 ms, total: 5.59 s\n",
-      "Wall time: 6.42 s\n"
+      "CPU times: user 6.13 s, sys: 313 ms, total: 6.44 s\n",
+      "Wall time: 10.5 s\n"
      ]
     }
    ],
@@ -119,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 4,
    "id": "236ab2f5-79a8-415b-a2e5-4767d67897f4",
    "metadata": {},
    "outputs": [],
@@ -137,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 5,
    "id": "0c4f799e-4ce3-40ba-96d2-bffc965329a0",
    "metadata": {},
    "outputs": [
@@ -163,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 6,
    "id": "453bb74c-9033-49e0-8d66-79df2fc99e86",
    "metadata": {},
    "outputs": [
@@ -193,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 7,
    "id": "c6cbf175-b255-4459-a1d9-a08644e9304d",
    "metadata": {},
    "outputs": [
@@ -220,18 +219,20 @@
    "source": [
     "## Zip files for distribution\n",
     "\n",
-    "Here we will zip the files for distribution. We will zip them by variable."
+    "Here we will zip the files for distribution. We will zip them by variable. Specify the path to write these zips in the prompt below:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 8,
    "id": "5f528fb8-83bc-4aca-a356-5a0bfa4d5f00",
    "metadata": {},
    "outputs": [],
    "source": [
+    "zip_dir = Path(input(\"Specify path to place zips in: \") or \".\")\n",
+    "\n",
     "for alf_name in alf_names:\n",
-    "    command = f\"bash ./zipit.sh {data_dir} {alf_name} {out_dir}\"\n",
+    "    command = f\"bash ./zipit.sh {data_dir} {alf_name} {zip_dir}\"\n",
     "    output = subprocess.check_output(command, shell=True)"
    ]
   },
@@ -245,26 +246,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 10,
    "id": "5dba6135-b3a8-48ce-97b0-64d77cd3de11",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[PosixPath('/workspace/Shared/Tech_Projects/Alaska_IEM/final_products/NCR_ALFRESCO_zips/alfresco_vegetation_type_percentage.zip'),\n",
-       " PosixPath('/workspace/Shared/Tech_Projects/Alaska_IEM/final_products/NCR_ALFRESCO_zips/alfresco_vegetation_mode_statistic.zip'),\n",
-       " PosixPath('/workspace/Shared/Tech_Projects/Alaska_IEM/final_products/NCR_ALFRESCO_zips/alfresco_relative_flammability_30yr.zip')]"
+       "[PosixPath('alfresco_vegetation_type_percentage.zip'),\n",
+       " PosixPath('alfresco_vegetation_mode_statistic.zip'),\n",
+       " PosixPath('alfresco_relative_flammability_30yr.zip')]"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# did we zip 'em all?\n",
-    "zips = list(out_dir.glob(\"*.zip\"))\n",
+    "zips = list(zip_dir.glob(\"*.zip\"))\n",
     "zips"
    ]
   },
@@ -276,8 +277,9 @@
     "Looks like it. Make a directory in Poseidon and copy these files (/workspace/CKAN not available on compute node):\n",
     "\n",
     "```\n",
-    "cp /workspace/Shared/Tech_Projects/Alaska_IEM/final_products/NCR_ALFRESCO_zips/alfresco_vegetation*.zip /workspace/CKAN/CKAN_Data/IEM/Outputs/ALF/Gen_1a/alfresco_relative_spatial_outputs/vegetation_type\n",
-    "cp /workspace/Shared/Tech_Projects/Alaska_IEM/final_products/NCR_ALFRESCO_zips/alfresco_relative_flammability_30yr.zip /workspace/CKAN/CKAN_Data/IEM/Outputs/ALF/Gen_1a/alfresco_relative_spatial_outputs/relative_flammability/AR5_CMIP5/\n",
+    "cp *.zip /workspace/Shared/Tech_Projects/Alaska_IEM/final_products/NCR_ALFRESCO_zips/\n",
+    "cp alfresco_vegetation*.zip /workspace/CKAN/CKAN_Data/IEM/Outputs/ALF/Gen_1a/alfresco_relative_spatial_outputs/vegetation_type\n",
+    "cp alfresco_relative_flammability_30yr.zip /workspace/CKAN/CKAN_Data/IEM/Outputs/ALF/Gen_1a/alfresco_relative_spatial_outputs/relative_flammability/AR5_CMIP5/\n",
     "```"
    ]
   }

--- a/iem/alfresco/portal_prep.ipynb
+++ b/iem/alfresco/portal_prep.ipynb
@@ -220,7 +220,7 @@
    "source": [
     "## Zip files for distribution\n",
     "\n",
-    "Here we will zip the files for distribution. We will zip them by degree day variable."
+    "Here we will zip the files for distribution. We will zip them by variable."
    ]
   },
   {

--- a/iem/alfresco/portal_prep.ipynb
+++ b/iem/alfresco/portal_prep.ipynb
@@ -1,0 +1,306 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "44b3698c-6075-464e-aff1-c67319c66fbe",
+   "metadata": {},
+   "source": [
+    "# Prepare ALFRESCO vegetation and flammability datasets for hosting\n",
+    "\n",
+    "This notebook captures information from the ALFRESCO vegetation and flammability datasets for generating a standard metadata / GeoNetwork entry, and creates helpful `.zip`s for distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5ef95df6-70a2-42c5-a611-5bfa8ed16a18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import subprocess\n",
+    "from pathlib import Path\n",
+    "import rasterio as rio\n",
+    "from rasterio.crs import CRS\n",
+    "from rasterio.warp import transform_bounds\n",
+    "import numpy as np\n",
+    "\n",
+    "data_dir = Path(\"/workspace/Shared/Tech_Projects/Alaska_IEM/project_data/NCR_ALFRESCO_datasets/\")\n",
+    "out_dir = Path(\"/workspace/Shared/Tech_Projects/Alaska_IEM/final_products/NCR_ALFRESCO_zips\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10fa6b10-8cd3-4792-a478-26296a0b544b",
+   "metadata": {},
+   "source": [
+    "### Spatial info: extent in WGS84, resolution, dimensions\n",
+    "\n",
+    "Get the spatial extent of this dataset in WGS84 (and use as an opportunity to ensure they are all the same)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88b72816-90d3-4a92-851d-f88ea2ccbcfc",
+   "metadata": {},
+   "source": [
+    "Use a [function](https://github.com/ua-snap/snap-geo/blob/e65e2d9aee0a1a0ea8c3432b3d01807476316206/antimeridian_raster_bbox.ipynb) to get WGS84 extent when the west side crosses the dateline. Adapt it to pull the resolution and spatial dimension sizes as well. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8d1fdc0b-a0bc-4677-ad82-064efc9297f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_wgs84_extent(gtiff_fp):\n",
+    "    with rio.open(gtiff_fp) as src:\n",
+    "        src_crs = src.crs\n",
+    "        src_bounds = src.bounds\n",
+    "        x_res = src.transform[0]\n",
+    "        y_res = -src.transform[4]\n",
+    "        width, height = src.width, src.height\n",
+    "    dst_crs = CRS.from_wkt(\n",
+    "        CRS.from_epsg(4326).to_wkt().replace('PRIMEM[\"Greenwich\",0', 'PRIMEM[\"Greenwich\",180')\n",
+    "    )\n",
+    "    bounds = transform_bounds(src_crs, dst_crs, *src_bounds)\n",
+    "    new_bounds = np.round((bounds[0] - 180, bounds[1], bounds[2] - 180, bounds[3]), 4)\n",
+    "    \n",
+    "    return new_bounds, x_res, y_res, width, height"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abc1de46-d540-49cd-b565-930e655d4545",
+   "metadata": {},
+   "source": [
+    "Iterate over all files in the dataset and extract the spatial info, appending to lists for verification of uniformity:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "8a9cf213-f3d0-4196-a79b-bf11c4ecb0cc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 5.32 s, sys: 276 ms, total: 5.59 s\n",
+      "Wall time: 6.42 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "alf_names = [\"alfresco_vegetation_type_percentage\", \"alfresco_vegetation_mode_statistic\", \"alfresco_relative_flammability_30yr\"]\n",
+    "all_bounds = []\n",
+    "x_sizes, y_sizes = [], []\n",
+    "widths, heights = [], []\n",
+    "for alf_name in alf_names:\n",
+    "    fps = list(data_dir.joinpath(alf_name).glob(\"*.tif\"))\n",
+    "    out = [get_wgs84_extent(fp) for fp in fps]\n",
+    "    all_bounds.extend([o[0] for o in out])\n",
+    "    x_sizes.extend([o[1] for o in out])\n",
+    "    y_sizes.extend([o[2] for o in out])\n",
+    "    widths.extend([o[3] for o in out])\n",
+    "    heights.extend([o[4] for o in out])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22ac7d49-5726-4a76-9ad4-604393092c87",
+   "metadata": {},
+   "source": [
+    "If the below cell executes without error, then all files have the same extent:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "236ab2f5-79a8-415b-a2e5-4767d67897f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert np.all([all_bounds[0] == bnds for bnds in all_bounds])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84eab4f7-369b-4535-bb9b-84c18e2e518d",
+   "metadata": {},
+   "source": [
+    "View those bounds for inclusion in metadata file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "0c4f799e-4ce3-40ba-96d2-bffc965329a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WSEN bounds: [-197.3058   50.3484 -107.1439   72.932 ]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"WSEN bounds:\", all_bounds[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "220b5428-d53d-48a5-b1c7-5eef0a3598ce",
+   "metadata": {},
+   "source": [
+    "Likewise, confirm that all files have the same X and Y sizes, and print those sizes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "453bb74c-9033-49e0-8d66-79df2fc99e86",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X resolution: 1000.0\n",
+      "Y resolution: 1000.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "assert np.all([x_sizes[0] == res for res in x_sizes])\n",
+    "assert np.all([y_sizes[0] == res for res in y_sizes])\n",
+    "print(\"X resolution:\", x_sizes[0])\n",
+    "print(\"Y resolution:\", y_sizes[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87903fd5-a1f2-46bb-b7ad-c0efe2581baa",
+   "metadata": {},
+   "source": [
+    "Confirm that all files have the same shape, and print those:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "c6cbf175-b255-4459-a1d9-a08644e9304d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X dimension size: 3650\n",
+      "Y dimension size: 2100\n"
+     ]
+    }
+   ],
+   "source": [
+    "assert np.all([widths[0] == w for w in widths])\n",
+    "assert np.all([heights[0] == h for h in heights])\n",
+    "print(\"X dimension size:\", widths[0])\n",
+    "print(\"Y dimension size:\", heights[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d9b5423-e7c6-47b3-a1e9-2d9e7df830f6",
+   "metadata": {},
+   "source": [
+    "## Zip files for distribution\n",
+    "\n",
+    "Here we will zip the files for distribution. We will zip them by degree day variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "5f528fb8-83bc-4aca-a356-5a0bfa4d5f00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for alf_name in alf_names:\n",
+    "    command = f\"bash ./zipit.sh {data_dir} {alf_name} {out_dir}\"\n",
+    "    output = subprocess.check_output(command, shell=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d9f2f16-ef53-4386-a6d5-a97178f89f57",
+   "metadata": {},
+   "source": [
+    "Did we zip them all?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "5dba6135-b3a8-48ce-97b0-64d77cd3de11",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PosixPath('/workspace/Shared/Tech_Projects/Alaska_IEM/final_products/NCR_ALFRESCO_zips/alfresco_vegetation_type_percentage.zip'),\n",
+       " PosixPath('/workspace/Shared/Tech_Projects/Alaska_IEM/final_products/NCR_ALFRESCO_zips/alfresco_vegetation_mode_statistic.zip'),\n",
+       " PosixPath('/workspace/Shared/Tech_Projects/Alaska_IEM/final_products/NCR_ALFRESCO_zips/alfresco_relative_flammability_30yr.zip')]"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# did we zip 'em all?\n",
+    "zips = list(out_dir.glob(\"*.zip\"))\n",
+    "zips"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbd63670-0484-400d-b5d8-0291a0272575",
+   "metadata": {},
+   "source": [
+    "Looks like it. Make a directory in Poseidon and copy these files (/workspace/CKAN not available on compute node):\n",
+    "\n",
+    "```\n",
+    "cp /workspace/Shared/Tech_Projects/Alaska_IEM/final_products/NCR_ALFRESCO_zips/alfresco_vegetation*.zip /workspace/CKAN/CKAN_Data/IEM/Outputs/ALF/Gen_1a/alfresco_relative_spatial_outputs/vegetation_type\n",
+    "cp /workspace/Shared/Tech_Projects/Alaska_IEM/final_products/NCR_ALFRESCO_zips/alfresco_relative_flammability_30yr.zip /workspace/CKAN/CKAN_Data/IEM/Outputs/ALF/Gen_1a/alfresco_relative_spatial_outputs/relative_flammability/AR5_CMIP5/\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/iem/alfresco/zipit.sh
+++ b/iem/alfresco/zipit.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+directory="$1"
+alf_name="$2"
+zip_directory="$3"
+
+zip_file="${zip_directory}/${alf_name}.zip"
+
+echo "Creating ${zip_file}"
+# delete zip archive if it exists already
+rm -f "${zip_file}"
+
+# create a zip file for the variable and add all tiffs with this string in their filename to the zip
+find "${directory}/${alf_name}" -name "*.tif" -print0 | xargs -0 zip -j "${zip_file}"


### PR DESCRIPTION
This PR adds a single Jupyter notebook (`iem/alfresco/portal_prep.ipynb`) for extracting metadata from and zipping the recent (2022) summarized ALFRESCO data for hosting via the SNAP GeoNetwork data portal:

*  vegetation type data (new) ([here](https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/a077b382-c7e5-44a7-8b2a-1cf764c448f6)). 
* updated summaries of the flammability data which have been added to [this entry](https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/eeaaca2c-0280-4226-b126-fda42a2b6214).  

This also includes a `zipit.sh` script for helping to zip the data files, which is executed from the notebook. To review, feel free to just have a look without running, or run the whole notebook. Any feedback is welcome! No rush on this.