### PR TITLE
Fixes import error due to regex not matching file naming convention coming from Python notebook.

### DIFF
--- a/iem/alfresco/relative_flammability/ingest.json
+++ b/iem/alfresco/relative_flammability/ingest.json
@@ -61,7 +61,7 @@
           "type": "gdal",
           "axes": {
             "era": {
-              "statements": "import imp, os; luts = imp.load_source('luts', os.getenv('LUTS_PATH')); regex_str = '([0-9]{4}-[0-9]{4})_(MRI-CGCM3|MODEL-SPINUP|NCAR-CCSM4|5modelAvg|GISS-E2-R|IPSL-CM5A-LR|GFDL-CM3)_(.*?).tif'",
+              "statements": "import imp, os; luts = imp.load_source('luts', os.getenv('LUTS_PATH')); regex_str = 'alfresco_relative_flammability_([0-9]{4}-[0-9]{4})_(MRI-CGCM3|MODEL-SPINUP|NCAR-CCSM4|5modelAvg|GISS-E2-R|IPSL-CM5A-LR|GFDL-CM3)_(.*?).tif'",
               "min": "luts.eras[regex_extract('${file:name}', regex_str, 1)]",
               "irregular": true,
               "dataBound": false


### PR DESCRIPTION
This small fix allows for the ingest.json script to identify the relevant portions of the file name for defining the various axes of the ALFRESCO flammability data. Without this, the ingest fails in a rather indiscernible fashion with a nasty error that has no relevance to the actual issue at hand.  