### PR TITLE
Update Arctic-EDS styles for degree days coverages

### DIFF
--- a/arctic_eds/degree_days/air_freezing_index_Fdays/ingest.json
+++ b/arctic_eds/degree_days/air_freezing_index_Fdays/ingest.json
@@ -14,7 +14,7 @@
         {
             "description": "Create future freezing index WMS style",
             "when": "after_import",
-            "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=air_freezing_index_Fdays&STYLEID=arctic_eds_freezing_index_future_condensed&ABSTRACT=Average%20of%20years%20from%202040-2069&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2891%3A120%29%20using%20%24c%5Byear%28%24t%29%2C%20model%282%29%2C%20scenario%282%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
+            "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=air_freezing_index_Fdays&STYLEID=arctic_eds_freezing_index_future&ABSTRACT=Average%20of%20years%20from%202040-2069&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2891%3A120%29%20using%20%24c%5Byear%28%24t%29%2C%20model%282%29%2C%20scenario%282%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"intervals\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
               \\\"-1\\\": [0, 0, 0, 0],
               \\\"0\\\": [255,247,251,255],
               \\\"1000\\\": [236,231,242,255],
@@ -29,7 +29,7 @@
         {
             "description": "Create historical freezing index WMS style",
             "when": "after_import",
-            "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=air_freezing_index_Fdays&STYLEID=arctic_eds_freezing_index_historical_condensed&ABSTRACT=Average%20of%20years%20from%201980-2009&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2831%3A60%29%20using%20%24c%5Byear%28%24t%29%2C%20model%280%29%2C%20scenario%280%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
+            "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=air_freezing_index_Fdays&STYLEID=arctic_eds_freezing_index_historical&ABSTRACT=Average%20of%20years%20from%201980-2009&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2831%3A60%29%20using%20%24c%5Byear%28%24t%29%2C%20model%280%29%2C%20scenario%280%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"intervals\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
               \\\"-1\\\": [0, 0, 0, 0],
               \\\"0\\\": [255,247,251,255],
               \\\"1000\\\": [236,231,242,255],

--- a/arctic_eds/degree_days/air_thawing_index_Fdays/ingest.json
+++ b/arctic_eds/degree_days/air_thawing_index_Fdays/ingest.json
@@ -14,7 +14,7 @@
         {
             "description": "Create future thawing index WMS style",
             "when": "after_import",
-            "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=air_thawing_index_Fdays&STYLEID=arctic_eds_thawing_index_future_condensed_compressed&ABSTRACT=Average%20of%20years%20from%202040-2069&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2891%3A120%29%20using%20%24c%5Byear%28%24t%29%2C%20model%282%29%2C%20scenario%282%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
+            "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=air_thawing_index_Fdays&STYLEID=arctic_eds_thawing_index_future&ABSTRACT=Average%20of%20years%20from%202040-2069&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2891%3A120%29%20using%20%24c%5Byear%28%24t%29%2C%20model%282%29%2C%20scenario%282%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"intervals\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
               \\\"-1\\\": [0, 0, 0, 0],
               \\\"0\\\": [255,247,251,255],
               \\\"1000\\\": [254,227,145,255],
@@ -27,7 +27,7 @@
         {
             "description": "Create historical thawing index WMS style",
             "when": "after_import",
-            "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=air_thawing_index_Fdays&STYLEID=arctic_eds_thawing_index_historical_condensed_compressed&ABSTRACT=Average%20of%20years%20from%201980-2009&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2831%3A60%29%20using%20%24c%5Byear%28%24t%29%2C%20model%280%29%2C%20scenario%280%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
+            "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=air_thawing_index_Fdays&STYLEID=arctic_eds_thawing_index_historical&ABSTRACT=Average%20of%20years%20from%201980-2009&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2831%3A60%29%20using%20%24c%5Byear%28%24t%29%2C%20model%280%29%2C%20scenario%280%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"intervals\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
               \\\"-1\\\": [0, 0, 0, 0],
               \\\"0\\\": [255,247,251,255],
               \\\"1000\\\": [254,227,145,255],

--- a/arctic_eds/degree_days/heating_degree_days_Fdays/ingest.json
+++ b/arctic_eds/degree_days/heating_degree_days_Fdays/ingest.json
@@ -14,7 +14,7 @@
         {
             "description": "Create EDS future WMS style",
             "when": "after_import",
-            "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=heating_degree_days_Fdays&STYLEID=arctic_eds_heating_degree_days_future_condensed_compressed&ABSTRACT=Average%20of%20years%20from%202040-2069&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2890%3A119%29%20using%20%24c%5Byear%28%24t%29%2C%20model%282%29%2C%20scenario%282%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
+            "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=heating_degree_days_Fdays&STYLEID=arctic_eds_heating_degree_days_future&ABSTRACT=Average%20of%20years%20from%202040-2069&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2890%3A119%29%20using%20%24c%5Byear%28%24t%29%2C%20model%282%29%2C%20scenario%282%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"intervals\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
               \\\"-1\\\": [0, 0, 0, 0],
               \\\"0\\\": [255,247,251,255],
               \\\"2500\\\": [236,231,242,255],
@@ -29,7 +29,7 @@
 	{
             "description": "Create EDS historical WMS style",
             "when": "after_import",
-            "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=heating_degree_days_Fdays&STYLEID=arctic_eds_heating_degree_days_historical_condensed_compressed&ABSTRACT=Average%20of%20years%20from%201980-2009&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2830%3A59%29%20using%20%24c%5Byear%28%24t%29%2C%20model%282%29%2C%20scenario%282%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
+            "cmd": "curl \"http://localhost:8080/rasdaman/admin/layer/style/add?COVERAGEID=heating_degree_days_Fdays&STYLEID=arctic_eds_heating_degree_days_historical&ABSTRACT=Average%20of%20years%20from%201980-2009&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2830%3A59%29%20using%20%24c%5Byear%28%24t%29%2C%20model%282%29%2C%20scenario%282%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"intervals\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
               \\\"-1\\\": [0, 0, 0, 0],
               \\\"0\\\": [255,247,251,255],
               \\\"2500\\\": [236,231,242,255],


### PR DESCRIPTION
I noticed that some of the color maps in the ingest scripts for the new degree days coverages (in branch `degree_days_prefect_remix`) were still using `ramp` based color maps, not `intervals`, because they were probably based on the outdated/unused Arctic-EDS styles we had added to Zeus during Arctic-EDS development way back when. This PR simply updates those Arctic-EDS color maps to use `intervals` so they are in sync with the production Arctic-EDS color maps we have on Apollo.

I also noticed that we had cleaned up the Arctic-EDS style names somewhere along the way so they didn't have the strange "*_condensed_compressed" business (on Apollo), so I've gone ahead and cleaned up the style names in this PR also.

To test, I successfully ingested one of the three affected coverages into Zeus (`air_freezing_index_Fdays`), pointed a local instance of the Arctic-EDS app against it, and confirmed that the intervals-based color map was working properly. I only tested this for one coverage because the same change was made for the other two coverages, so I'm confident that everything is working as intended!

Closes #67, btw!