### PR TITLE
Update Wet Days Per Year Arctic-EDS styles with intervals-based color maps

### DIFF
--- a/arctic_eds/wet_days_per_year/ingest.json
+++ b/arctic_eds/wet_days_per_year/ingest.json
@@ -9,29 +9,15 @@
   },
   "hooks": [
     {
-      "description": "Create projected wet days per year style for WMS Layer",
+      "description": "Create historical Wet Days Per Year WMS style for Arctic-EDS",
       "when": "after_import",
-      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=wet_days_per_year&STYLEID=arctic_eds_projected_wet_days_per_year&ABSTRACT=Average%20of%20years%20from%202040-2069&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2861%3A90%29%20using%20%24c%5Byear%28%24t%29%2C%20model%282%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
-        \\\"-1\\\": [0, 0, 0, 0],
-        \\\"0\\\": [237,248,251,255],
-        \\\"60\\\": [204,236,230,255],
-        \\\"120\\\": [153,216,201,255],
-        \\\"180\\\": [102,194,164,255],
-        \\\"240\\\": [44,162,95,255],
-        \\\"300\\\": [0,109,44,255] } }\"",
+      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=wet_days_per_year&STYLEID=arctic_eds_historical_wet_days_per_year&ABSTRACT=Average%20of%20years%20from%201980-2009&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%281%3A30%29%20using%20%24c%5Byear%28%24t%29%2C%20model%280%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\":\\\"intervals\\\",\\\"colorTable\\\":{\\\"-9999\\\":[0,0,0,0],\\\"-1\\\":[0,0,0,0],\\\"0\\\":[237,248,251,255],\\\"60\\\":[204,236,230,255],\\\"120\\\":[153,216,201,255],\\\"180\\\":[102,194,164,255]}}\"",
       "abort_on_error": true
     },
     {
-      "description": "Create historical wet days per year style for WMS Layer",
+      "description": "Create projected Wet Days Per Year WMS style for Arctic-EDS",
       "when": "after_import",
-      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=wet_days_per_year&STYLEID=arctic_eds_historical_wet_days_per_year&ABSTRACT=Average%20of%20years%20from%201980-2009&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%281%3A30%29%20using%20%24c%5Byear%28%24t%29%2C%20model%280%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
-        \\\"-1\\\": [0, 0, 0, 0],
-        \\\"0\\\": [237,248,251,255],
-        \\\"60\\\": [204,236,230,255],
-        \\\"120\\\": [153,216,201,255],
-        \\\"180\\\": [102,194,164,255],
-        \\\"240\\\": [44,162,95,255],
-        \\\"300\\\": [0,109,44,255] } }\"",
+      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=wet_days_per_year&STYLEID=arctic_eds_projected_wet_days_per_year&ABSTRACT=Average%20of%20years%20from%202040-2069&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2861%3A90%29%20using%20%24c%5Byear%28%24t%29%2C%20model%282%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\":\\\"intervals\\\",\\\"colorTable\\\":{\\\"-9999\\\":[0,0,0,0],\\\"-1\\\":[0,0,0,0],\\\"0\\\":[237,248,251,255],\\\"60\\\":[204,236,230,255],\\\"120\\\":[153,216,201,255],\\\"180\\\":[102,194,164,255]}}\"",
       "abort_on_error": true
     },
     {


### PR DESCRIPTION
Closes #102.

This PR updates the two Arctic-EDS WMS styles for the `wet_days_per_year` coverage to be `intervals`-based instead of `ramp`-based, and also adjusts the color thresholds slightly to correspond to the map legends on https://arcticeds.org/maps

I've already done a test ingest of this change with the new style hooks, and pointed a local copy of Arctic-EDS against it. Everything looked good & looks like the current production Arctic-EDS, so I don't think it's necessary to do additional testing.