### PR TITLE
Add WMS styles for Alaska Wildfire Explorer webapp to alfresco_relative_flammability_30yr coverage

### DIFF
--- a/iem/alfresco/relative_flammability/ingest.json
+++ b/iem/alfresco/relative_flammability/ingest.json
@@ -31,8 +31,7 @@
       "when": "after_import",
       "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=alfresco_relative_flammability_30yr&STYLEID=alaska_wildfire_explorer_projected&ABSTRACT=2070-2099%20flammability%20(Alaska%20Wildfire%20Explorer)&WCPSQUERYFRAGMENT=%24c%5Bera%284%29%5D&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\":\\\"intervals\\\",\\\"colorTable\\\":{\\\"-9999\\\":[0,0,0,0],\\\"0.000\\\":[254,240,217,255],\\\"0.002\\\":[253,204,138,255],\\\"0.005\\\":[252,141,89,255],\\\"0.010\\\":[227,74,51,255],\\\"0.020\\\":[179,0,0,255]}}\"",
       "abort_on_error": true
-},
-
+}
   ],
   "input": {
     "coverage_id": "alfresco_relative_flammability_30yr",

--- a/iem/alfresco/relative_flammability/ingest.json
+++ b/iem/alfresco/relative_flammability/ingest.json
@@ -19,7 +19,20 @@
       "when": "after_import",
       "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=alfresco_relative_flammability_30yr&STYLEID=ardac_flammability&ABSTRACT=Flammability&WCPSQUERYFRAGMENT=&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\":\\\"intervals\\\",\\\"colorTable\\\":{\\\"-9999\\\":[0,0,0,0],\\\"0.000\\\":[254,240,217,255],\\\"0.002\\\":[253,204,138,255],\\\"0.005\\\":[252,141,89,255],\\\"0.010\\\":[227,74,51,255],\\\"0.020\\\":[179,0,0,255]}}\"",
       "abort_on_error": true
-    }
+    },
+    {
+      "description": "Create historical Flammability WMS style for Alaska Wildfire Explorer",
+      "when": "after_import",
+      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=alfresco_relative_flammability_30yr&STYLEID=alaska_wildfire_explorer_historical&ABSTRACT=1950-2008%20flammability%20(Alaska%20Wildfire%20Explorer)&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24e%20era%280%3A1%29%20using%20%24c%5Bera%28%24e%29%5D%29%20%2F%202&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\":\\\"intervals\\\",\\\"colorTable\\\":{\\\"-9999\\\":[0,0,0,0],\\\"0.000\\\":[254,240,217,255],\\\"0.002\\\":[253,204,138,255],\\\"0.005\\\":[252,141,89,255],\\\"0.010\\\":[227,74,51,255],\\\"0.020\\\":[179,0,0,255]}}\"",
+      "abort_on_error": true
+},
+{
+      "description": "Create projected Flammability WMS style for Alaska Wildfire Explorer",
+      "when": "after_import",
+      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=alfresco_relative_flammability_30yr&STYLEID=alaska_wildfire_explorer_projected&ABSTRACT=2070-2099%20flammability%20(Alaska%20Wildfire%20Explorer)&WCPSQUERYFRAGMENT=%24c%5Bera%284%29%5D&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\":\\\"intervals\\\",\\\"colorTable\\\":{\\\"-9999\\\":[0,0,0,0],\\\"0.000\\\":[254,240,217,255],\\\"0.002\\\":[253,204,138,255],\\\"0.005\\\":[252,141,89,255],\\\"0.010\\\":[227,74,51,255],\\\"0.020\\\":[179,0,0,255]}}\"",
+      "abort_on_error": true
+},
+
   ],
   "input": {
     "coverage_id": "alfresco_relative_flammability_30yr",


### PR DESCRIPTION
Closes #109.

This PR adds two new WMS styles (historical + projected) to the `alfresco_relative_flammability_30yr` coverage for use with the Alaska Wildfire Explorer webapp. I ran a test ingest on Apollo to confirm that these WMS styles were added successfully, and also ran a local instances of Alaska Wildfire Explorer against the test coverage to make sure everything worked as expected. This is a trivial change otherwise, so I'm going to self-merge this PR.