### PR TITLE
Fix Arctic-EDS WMS style hooks to reflect production webapp maps

### DIFF
--- a/arctic_eds/annual_mean_pr/hook_ingest.json
+++ b/arctic_eds/annual_mean_pr/hook_ingest.json
@@ -11,27 +11,13 @@
     {
       "description": "Create Historical Precip Style for WMS Layer",
       "when": "after_import",
-      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=annual_precip_totals_mm&STYLEID=precip_mm_historical_era&ABSTRACT=Average%20annual%20precipitation%2C%201980-2009%2C%20CRU%20TS&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2879%3A108%29%20using%20%24c%5Byear%28%24t%29%2C%20model%280%29%2C%20scenario%280%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
-       \\\"0\\\": [140, 81, 10, 255],
-       \\\"254\\\": [216, 179, 101, 255],
-       \\\"508\\\": [246, 232, 195, 255],
-       \\\"1270\\\": [245, 245, 245, 255],
-       \\\"2540\\\": [199, 234, 229, 255],
-       \\\"5080\\\": [90, 180, 172, 255],
-       \\\"10160\\\": [1, 102, 94, 255] } }\"",
+      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=annual_precip_totals_mm&STYLEID=precip_mm_historical_era&ABSTRACT=Average%20annual%20precipitation,%201980-2009,%20CRU%20TS&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2879%3A108%29%20using%20%24c%5Byear%28%24t%29%2C%20model%280%29%2C%20scenario%280%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\":\\\"intervals\\\",\\\"colorTable\\\":{\\\"-9999\\\":[0,0,0,0],\\\"0\\\":[140,81,10,255],\\\"254\\\":[216,179,101,255],\\\"508\\\":[246,232,195,255],\\\"1270\\\":[245,245,245,255],\\\"2540\\\":[199,234,229,255],\\\"5080\\\":[90,180,172,255],\\\"10160\\\":[1,102,94,255]}}\"",
       "abort_on_error": true
     },
     {
       "description": "Create Projected Precip Style for WMS Layer",
       "when": "after_import",
-      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=annual_precip_totals_mm&STYLEID=precip_mm_midcentury_era&ABSTRACT=Average%20annual%20precipitation%2C%202040-2069%2C%20NCAR%20CCSM4%2C%20RCP%208.5&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%28139%3A168%29%20using%20%24c%5Byear%28%24t%29%2C%20model%286%29%2C%20scenario%283%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
-       \\\"0\\\": [140, 81, 10, 255],
-       \\\"254\\\": [216, 179, 101, 255],
-       \\\"508\\\": [246, 232, 195, 255],
-       \\\"1270\\\": [245, 245, 245, 255],
-       \\\"2540\\\": [199, 234, 229, 255],
-       \\\"5080\\\": [90, 180, 172, 255],
-       \\\"10160\\\": [1, 102, 94, 255] } }\"",
+      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=annual_precip_totals_mm&STYLEID=precip_mm_midcentury_era&ABSTRACT=Average%20annual%20precipitation,%202040-2069,%20NCAR%20CCSM4,%20RCP%208.5&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%28139%3A168%29%20using%20%24c%5Byear%28%24t%29%2C%20model%286%29%2C%20scenario%283%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\":\\\"intervals\\\",\\\"colorTable\\\":{\\\"-9999\\\":[0,0,0,0],\\\"0\\\":[140,81,10,255],\\\"254\\\":[216,179,101,255],\\\"508\\\":[246,232,195,255],\\\"1270\\\":[245,245,245,255],\\\"2540\\\":[199,234,229,255],\\\"5080\\\":[90,180,172,255],\\\"10160\\\":[1,102,94,255]}}\"",
       "abort_on_error": true
     }
   ],

--- a/arctic_eds/annual_mean_snowfall/hook_ingest.json
+++ b/arctic_eds/annual_mean_snowfall/hook_ingest.json
@@ -9,9 +9,9 @@
   },
   "hooks": [
     {
-      "description": "Create WMS Style for Layer",
+      "description": "Create Snowfall Style for WMS Layer",
       "when": "after_import",
-      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=mean_annual_snowfall_mm&STYLEID=snowfall_mm&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0], \\\"0\\\": [237, 248, 251, 255], \\\"50\\\": [191, 211, 230, 255], \\\"100\\\": [158, 188, 218, 255], \\\"500\\\": [140, 150, 198, 255], \\\"1000\\\": [140, 107, 177, 167], \\\"2000\\\": [136, 65, 167, 255], \\\"3000\\\": [110, 1, 107, 255] } }\"",
+      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=mean_annual_snowfall_mm&STYLEID=snowfall_mm&ABSTRACT=Snowfall&WCPSQUERYFRAGMENT=&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\":\\\"intervals\\\",\\\"colorTable\\\":{\\\"-9999\\\":[0,0,0,0],\\\"0\\\":[237,248,251,255],\\\"63.5\\\":[191,211,230,255],\\\"127\\\":[158,188,218,255],\\\"254\\\":[140,150,198,255],\\\"508\\\":[136,86,167,255],\\\"1270\\\":[129,15,124,255]}}\"",
       "abort_on_error": true
     }
   ],

--- a/arctic_eds/annual_mean_tas/hook_ingest.json
+++ b/arctic_eds/annual_mean_tas/hook_ingest.json
@@ -11,27 +11,13 @@
     {
       "description": "Create Historical Temp Style for WMS Layer",
       "when": "after_import",
-      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=annual_mean_temp&STYLEID=temp_historical_era&ABSTRACT=Average%20annual%20temperature%2C%201980-2009%2C%20CRU%20TS&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2879%3A108%29%20using%20%24c%5Byear%28%24t%29%2C%20model%280%29%2C%20scenario%280%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
-        \\\"-30\\\": [33, 102, 172, 255],
-        \\\"-15\\\": [103, 169, 207, 255],
-        \\\"-5\\\": [209, 229, 240, 255],
-        \\\"0\\\": [247, 247, 247, 255],
-        \\\"5\\\": [253, 219, 199, 255],
-        \\\"15\\\": [239, 138, 98, 255],
-        \\\"30\\\": [178, 24, 43, 255] } }\"",
+      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=annual_mean_temp&STYLEID=temp_historical_era&ABSTRACT=Average%20annual%20temperature,%201980-2009,%20CRU%20TS&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%2879%3A108%29%20using%20%24c%5Byear%28%24t%29%2C%20model%280%29%2C%20scenario%280%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\":\\\"intervals\\\",\\\"colorTable\\\":{\\\"-9999\\\":[0,0,0,0],\\\"-100\\\":[33,102,172,255],\\\"-12.22\\\":[67,147,195,255],\\\"-9.44\\\":[146,197,222,255],\\\"-6.67\\\":[209,229,240,255],\\\"-3.89\\\":[253,219,199,255],\\\"-1.11\\\":[244,165,130,255],\\\"1.67\\\":[214,96,77,255],\\\"4.44\\\":[178,24,43,255]}}\"",
       "abort_on_error": true
     },
     {
       "description": "Create Projected Temp Style for WMS Layer",
       "when": "after_import",
-      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=annual_mean_temp&STYLEID=temp_midcentury_era&ABSTRACT=Average%20annual%20temperature%2C%202040-2069%2C%20NCAR%20CCSM4%2C%20RCP%208.5&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%28139%3A168%29%20using%20%24c%5Byear%28%24t%29%2C%20model%286%29%2C%20scenario%283%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\": \\\"ramp\\\", \\\"colorTable\\\": {  \\\"-9999\\\": [0, 0, 0, 0],
-        \\\"-30\\\": [33, 102, 172, 255],
-        \\\"-15\\\": [103, 169, 207, 255],
-        \\\"-5\\\": [209, 229, 240, 255],
-        \\\"0\\\": [247, 247, 247, 255],
-        \\\"5\\\": [253, 219, 199, 255],
-        \\\"15\\\": [239, 138, 98, 255],
-        \\\"30\\\": [178, 24, 43, 255] } }\"",
+      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=annual_mean_temp&STYLEID=temp_midcentury_era&ABSTRACT=Average%20annual%20temperature,%202040-2069,%20NCAR%20CCSM4,%20RCP%208.5&WCPSQUERYFRAGMENT=%28condense%20%2B%20over%20%24t%20year%28139%3A168%29%20using%20%24c%5Byear%28%24t%29%2C%20model%286%29%2C%20scenario%283%29%5D%29%20%2F%2030&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\":\\\"intervals\\\",\\\"colorTable\\\":{\\\"-9999\\\":[0,0,0,0],\\\"-100\\\":[33,102,172,255],\\\"-12.22\\\":[67,147,195,255],\\\"-9.44\\\":[146,197,222,255],\\\"-6.67\\\":[209,229,240,255],\\\"-3.89\\\":[253,219,199,255],\\\"-1.11\\\":[244,165,130,255],\\\"1.67\\\":[214,96,77,255],\\\"4.44\\\":[178,24,43,255]}}\"",
       "abort_on_error": true
     }
   ],


### PR DESCRIPTION
Closes #115.

This PR updates the Arctic-EDS WMS style hooks for the following coverages:

- annual_precip_totals_mm
- annual_mean_temp
- snowfall_mm

The WMS styles have been updated to use `intervals`-based color maps, not `ramp`-based color maps, to reflect the color buckets in the corresponding map legends at https://arcticeds.org/maps. This is a change we originally made ~1+ years ago, but I had neglected to update the WSM styles in the ingest scripts at the time.

I already tried ingesting test versions of each of the 3 coverages using these new WMS style hooks, and pointed a local Arctic-EDS instance at them, and everything worked as expected and matched the current production maps at https://arcticeds.org/maps, so no extra testing necessary IMO.