### PR TITLE
Discard null mask of flammability NCR WMS style to make nodata white

### DIFF
--- a/iem/alfresco/relative_flammability/ingest.json
+++ b/iem/alfresco/relative_flammability/ingest.json
@@ -11,7 +11,7 @@
     {
       "description": "Create Flammability WMS style for Northern Climate Reports",
       "when": "after_import",
-      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=alfresco_relative_flammability_30yr&STYLEID=climate_impact_reports&ABSTRACT=Flammability%20(NCR)&WCPSQUERYFRAGMENT=&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\":\\\"intervals\\\",\\\"colorTable\\\":{\\\"-9999\\\":[255,255,255,255],\\\"0.000\\\":[254,240,217,255],\\\"0.002\\\":[253,204,138,255],\\\"0.005\\\":[252,141,89,255],\\\"0.010\\\":[227,74,51,255],\\\"0.020\\\":[179,0,0,255]}}\"",
+      "cmd": ". /etc/default/rasdaman; curl --user $RASCURL \"https://datacubes.earthmaps.io/rasdaman/admin/layer/style/add?COVERAGEID=alfresco_relative_flammability_30yr&STYLEID=climate_impact_reports&ABSTRACT=Style%20for%20Climate%20Impact%20Reports%20web%20app%20relative%20flammability%20mini-maps.&WCPSQUERYFRAGMENT=%28%24c%29%20null%20mask%20discard&COLORTABLETYPE=ColorMap&\" --data-urlencode \"COLORTABLEDEFINITION={\\\"type\\\":\\\"intervals\\\",\\\"colorTable\\\":{\\\"-9999\\\":[255,255,255,255],\\\"0.000\\\":[254,240,217,255],\\\"0.002\\\":[253,204,138,255],\\\"0.005\\\":[252,141,89,255],\\\"0.010\\\":[227,74,51,255],\\\"0.020\\\":[179,0,0,255]}}\"",
       "abort_on_error": true
     },
     {


### PR DESCRIPTION
Closes #107.

This PR adds the following WCPS query to the `alfresco_relative_flammability_30yr` coverage:

```
($c) null mask discard
```

This WCPS query was provided by Rasdaman support months ago and allows nodata pixels in the `alfresco_relative_flammability_30yr` coverage to be styled as white, not transparent, to match the flammability mini-map legend in NCR. These pixels had been styled white already in a previous version of Rasdaman, but the WCPS query is now required to make the pixels white on the new version of Rasdaman (or this is possibly a Rasdaman Enterprise vs. Rasdaman Community issue, not 100% sure).

I've already run a test ingest using the modified WMS style hook and pointed a local instance of NCR at it, and everything works as planned, so no extra testing necessary IMO.

This WCPS query is already being used in production on Zeus. The WMS style abstract has also changed in this PR to the more descriptive version from Zeus.