### PR TITLE
Ingest the `_wcs` Daily SLIE Coverages

### DIFF
--- a/ardac/landfast_sea_ice_beaufort_daily/ingest_wcs_only.json
+++ b/ardac/landfast_sea_ice_beaufort_daily/ingest_wcs_only.json
@@ -26,11 +26,9 @@
           "metadata": {
             "type": "xml",
             "global": {
-              "Title": "'Beaufort Daily SLIE'",
-              "Encoding": {
-                }
-              }
-            },
+              "Title": "'Beaufort Daily SLIE'"
+            }
+          },
           "slicer": {
             "type": "netcdf",
             "pixelIsPoint": true,

--- a/ardac/landfast_sea_ice_chukchi_daily/ingest_wcs_only.json
+++ b/ardac/landfast_sea_ice_chukchi_daily/ingest_wcs_only.json
@@ -26,11 +26,9 @@
           "metadata": {
             "type": "xml",
             "global": {
-              "Title": "'Chukchi Daily SLIE'",
-              "Encoding": {
-                }
-              }
-            },
+              "Title": "'Chukchi Daily SLIE'"
+            }
+          },
           "slicer": {
             "type": "netcdf",
             "pixelIsPoint": true,


### PR DESCRIPTION
This PR adds two new ingest recipes, one for the Chukchi Daily SLIE Coverage and one for the Beaufort Daily SLIE Coverage. The two new coverage IDs are:

`ardac_beaufort_daily_slie_wcs`

and

`ardac_chukchi_daily_slie_wcs`

These coverages are constructed with a tiling that will optimize queries that are small in X-Y, but long in time, e.g., "Give me the full time series of data at this location".

The new `_wcs` coverages **will not** support WMS. This is intentional - we've omitted the `wms_import` ingredient from the recipe. We are electing to do this because we know that the typical WMS query scheme (single time slice, full spatial domain) will not be responsive with this WCS specific tiling scheme.

To test this PR, see the XREF'd Prefect PR.

Closes #131 