### PR TITLE
initial commit of ERA5 WCS optimized recipes

### DIFF
--- a/ardac/daily_wrf_downscaled_era5/rainnc_sum_ingest_wcs_only.json
+++ b/ardac/daily_wrf_downscaled_era5/rainnc_sum_ingest_wcs_only.json
@@ -1,0 +1,68 @@
+{
+  "config": {
+    "service_url": "https://localhost/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "crs_resolver": "http://localhost:8080/def/",
+    "default_crs": "http://localhost:8080/def/crs/EPSG/0/3338",
+    "default_null_values": [
+      "nan"
+    ],
+    "mock": false,
+    "automated": true
+  },
+  "input": {
+    "coverage_id": "era5_4km_daily_rainnc_sum_wcs",
+    "paths": [
+      "rainnc_sum_merged.nc"
+    ]
+  },
+  "recipe": {
+    "name": "general_coverage",
+    "options": {
+      "import_order": "ascending",
+      "tiling": "ALIGNED [0:*, 0:7, 0:7] TILE SIZE 8388608",
+      "coverage": {
+        "crs": "OGC/0/AnsiDate?axis-label=\"time\"@EPSG/0/3338",
+        "metadata": {
+          "type": "xml",
+          "global": {
+            "Title": "'Daily Sum of Precipitation'"
+          }
+        },
+        "slicer": {
+          "type": "netcdf",
+          "pixelIsPoint": true,
+          "bands": [
+            {
+              "name": "rainnc_sum",
+              "identifier": "rainnc_sum"
+            }
+          ],
+          "axes": {
+            "time": {
+              "statements": "from datetime import datetime; import netCDF4",
+              "min": "netCDF4.num2date(${netcdf:variable:time:min}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "max": "netCDF4.num2date(${netcdf:variable:time:max}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "directPositions": "[netCDF4.num2date(x, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\") for x in ${netcdf:variable:time}]",
+              "gridOrder": 0,
+              "type": "ansidate",
+              "irregular": true
+            },
+            "X": {
+              "min": "${netcdf:variable:x:min}",
+              "max": "${netcdf:variable:x:max}",
+              "resolution": "${netcdf:variable:x:resolution}",
+              "gridOrder": 2
+            },
+            "Y": {
+              "min": "${netcdf:variable:y:min}",
+              "max": "${netcdf:variable:y:max}",
+              "resolution": "${netcdf:variable:y:resolution}",
+              "gridOrder": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ardac/daily_wrf_downscaled_era5/rh2_max_ingest_wcs_only.json
+++ b/ardac/daily_wrf_downscaled_era5/rh2_max_ingest_wcs_only.json
@@ -1,0 +1,68 @@
+{
+  "config": {
+    "service_url": "https://localhost/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "crs_resolver": "http://localhost:8080/def/",
+    "default_crs": "http://localhost:8080/def/crs/EPSG/0/3338",
+    "default_null_values": [
+      "nan"
+    ],
+    "mock": false,
+    "automated": true
+  },
+  "input": {
+    "coverage_id": "era5_4km_daily_rh2_max_wcs",
+    "paths": [
+      "rh2_max_merged.nc"
+    ]
+  },
+  "recipe": {
+    "name": "general_coverage",
+    "options": {
+      "tiling": "ALIGNED [0:*, 0:7, 0:7] TILE SIZE 8388608",
+      "import_order": "ascending",
+      "coverage": {
+        "crs": "OGC/0/AnsiDate?axis-label=\"time\"@EPSG/0/3338",
+        "metadata": {
+          "type": "xml",
+          "global": {
+            "Title": "'Daily Maximum 2m Relative Humidity'"
+          }
+        },
+        "slicer": {
+          "type": "netcdf",
+          "pixelIsPoint": true,
+          "bands": [
+            {
+              "name": "rh2_max",
+              "identifier": "rh2_max"
+            }
+          ],
+          "axes": {
+            "time": {
+              "statements": "from datetime import datetime; import netCDF4",
+              "min": "netCDF4.num2date(${netcdf:variable:time:min}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "max": "netCDF4.num2date(${netcdf:variable:time:max}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "directPositions": "[netCDF4.num2date(x, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\") for x in ${netcdf:variable:time}]",
+              "gridOrder": 0,
+              "type": "ansidate",
+              "irregular": true
+            },
+            "X": {
+              "min": "${netcdf:variable:x:min}",
+              "max": "${netcdf:variable:x:max}",
+              "resolution": "${netcdf:variable:x:resolution}",
+              "gridOrder": 2
+            },
+            "Y": {
+              "min": "${netcdf:variable:y:min}",
+              "max": "${netcdf:variable:y:max}",
+              "resolution": "${netcdf:variable:y:resolution}",
+              "gridOrder": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ardac/daily_wrf_downscaled_era5/rh2_mean_ingest_wcs_only.json
+++ b/ardac/daily_wrf_downscaled_era5/rh2_mean_ingest_wcs_only.json
@@ -1,0 +1,68 @@
+{
+  "config": {
+    "service_url": "https://localhost/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "crs_resolver": "http://localhost:8080/def/",
+    "default_crs": "http://localhost:8080/def/crs/EPSG/0/3338",
+    "default_null_values": [
+      "nan"
+    ],
+    "mock": false,
+    "automated": true
+  },
+  "input": {
+    "coverage_id": "era5_4km_daily_rh2_mean_wcs",
+    "paths": [
+      "rh2_mean_merged.nc"
+    ]
+  },
+  "recipe": {
+    "name": "general_coverage",
+    "options": {
+      "tiling": "ALIGNED [0:*, 0:7, 0:7] TILE SIZE 8388608",
+      "import_order": "ascending",
+      "coverage": {
+        "crs": "OGC/0/AnsiDate?axis-label=\"time\"@EPSG/0/3338",
+        "metadata": {
+          "type": "xml",
+          "global": {
+            "Title": "'Daily Mean 2m Relative Humidity'"
+          }
+        },
+        "slicer": {
+          "type": "netcdf",
+          "pixelIsPoint": true,
+          "bands": [
+            {
+              "name": "rh2_mean",
+              "identifier": "rh2_mean"
+            }
+          ],
+          "axes": {
+            "time": {
+              "statements": "from datetime import datetime; import netCDF4",
+              "min": "netCDF4.num2date(${netcdf:variable:time:min}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "max": "netCDF4.num2date(${netcdf:variable:time:max}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "directPositions": "[netCDF4.num2date(x, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\") for x in ${netcdf:variable:time}]",
+              "gridOrder": 0,
+              "type": "ansidate",
+              "irregular": true
+            },
+            "X": {
+              "min": "${netcdf:variable:x:min}",
+              "max": "${netcdf:variable:x:max}",
+              "resolution": "${netcdf:variable:x:resolution}",
+              "gridOrder": 2
+            },
+            "Y": {
+              "min": "${netcdf:variable:y:min}",
+              "max": "${netcdf:variable:y:max}",
+              "resolution": "${netcdf:variable:y:resolution}",
+              "gridOrder": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ardac/daily_wrf_downscaled_era5/rh2_min_ingest_wcs_only.json
+++ b/ardac/daily_wrf_downscaled_era5/rh2_min_ingest_wcs_only.json
@@ -1,0 +1,68 @@
+{
+  "config": {
+    "service_url": "https://localhost/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "crs_resolver": "http://localhost:8080/def/",
+    "default_crs": "http://localhost:8080/def/crs/EPSG/0/3338",
+    "default_null_values": [
+      "nan"
+    ],
+    "mock": false,
+    "automated": true
+  },
+  "input": {
+    "coverage_id": "era5_4km_daily_rh2_min_wcs",
+    "paths": [
+      "rh2_min_merged.nc"
+    ]
+  },
+  "recipe": {
+    "name": "general_coverage",
+    "options": {
+      "tiling": "ALIGNED [0:*, 0:7, 0:7] TILE SIZE 8388608",
+      "import_order": "ascending",
+      "coverage": {
+        "crs": "OGC/0/AnsiDate?axis-label=\"time\"@EPSG/0/3338",
+        "metadata": {
+          "type": "xml",
+          "global": {
+            "Title": "'Daily Minimum 2m Relative Humidity'"
+          }
+        },
+        "slicer": {
+          "type": "netcdf",
+          "pixelIsPoint": true,
+          "bands": [
+            {
+              "name": "rh2_min",
+              "identifier": "rh2_min"
+            }
+          ],
+          "axes": {
+            "time": {
+              "statements": "from datetime import datetime; import netCDF4",
+              "min": "netCDF4.num2date(${netcdf:variable:time:min}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "max": "netCDF4.num2date(${netcdf:variable:time:max}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "directPositions": "[netCDF4.num2date(x, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\") for x in ${netcdf:variable:time}]",
+              "gridOrder": 0,
+              "type": "ansidate",
+              "irregular": true
+            },
+            "X": {
+              "min": "${netcdf:variable:x:min}",
+              "max": "${netcdf:variable:x:max}",
+              "resolution": "${netcdf:variable:x:resolution}",
+              "gridOrder": 2
+            },
+            "Y": {
+              "min": "${netcdf:variable:y:min}",
+              "max": "${netcdf:variable:y:max}",
+              "resolution": "${netcdf:variable:y:resolution}",
+              "gridOrder": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ardac/daily_wrf_downscaled_era5/seaice_max_ingest_wcs_only.json
+++ b/ardac/daily_wrf_downscaled_era5/seaice_max_ingest_wcs_only.json
@@ -1,0 +1,68 @@
+{
+  "config": {
+    "service_url": "https://localhost/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "crs_resolver": "http://localhost:8080/def/",
+    "default_crs": "http://localhost:8080/def/crs/EPSG/0/3338",
+    "default_null_values": [
+      "nan"
+    ],
+    "mock": false,
+    "automated": true
+  },
+  "input": {
+    "coverage_id": "era5_4km_daily_seaice_max_wcs",
+    "paths": [
+      "seaice_max_merged.nc"
+    ]
+  },
+  "recipe": {
+    "name": "general_coverage",
+    "options": {
+      "import_order": "ascending",
+      "tiling": "ALIGNED [0:*, 0:7, 0:7] TILE SIZE 8388608",
+      "coverage": {
+        "crs": "OGC/0/AnsiDate?axis-label=\"time\"@EPSG/0/3338",
+        "metadata": {
+          "type": "xml",
+          "global": {
+            "Title": "'Daily Maximum Sea Ice Concentration'"
+          }
+        },
+        "slicer": {
+          "type": "netcdf",
+          "pixelIsPoint": true,
+          "bands": [
+            {
+              "name": "seaice_max",
+              "identifier": "seaice_max"
+            }
+          ],
+          "axes": {
+            "time": {
+              "statements": "from datetime import datetime; import netCDF4",
+              "min": "netCDF4.num2date(${netcdf:variable:time:min}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "max": "netCDF4.num2date(${netcdf:variable:time:max}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "directPositions": "[netCDF4.num2date(x, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\") for x in ${netcdf:variable:time}]",
+              "gridOrder": 0,
+              "type": "ansidate",
+              "irregular": true
+            },
+            "X": {
+              "min": "${netcdf:variable:x:min}",
+              "max": "${netcdf:variable:x:max}",
+              "resolution": "${netcdf:variable:x:resolution}",
+              "gridOrder": 2
+            },
+            "Y": {
+              "min": "${netcdf:variable:y:min}",
+              "max": "${netcdf:variable:y:max}",
+              "resolution": "${netcdf:variable:y:resolution}",
+              "gridOrder": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ardac/daily_wrf_downscaled_era5/t2_max_ingest_wcs_only.json
+++ b/ardac/daily_wrf_downscaled_era5/t2_max_ingest_wcs_only.json
@@ -1,0 +1,68 @@
+{
+  "config": {
+    "service_url": "https://localhost/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "crs_resolver": "http://localhost:8080/def/",
+    "default_crs": "http://localhost:8080/def/crs/EPSG/0/3338",
+    "default_null_values": [
+      "nan"
+    ],
+    "mock": false,
+    "automated": true
+  },
+  "input": {
+    "coverage_id": "era5_4km_daily_t2_max_wcs",
+    "paths": [
+      "t2_max_merged.nc"
+    ]
+  },
+  "recipe": {
+    "name": "general_coverage",
+    "options": {
+      "import_order": "ascending",
+      "tiling": "ALIGNED [0:*, 0:7, 0:7] TILE SIZE 8388608",
+      "coverage": {
+        "crs": "OGC/0/AnsiDate?axis-label=\"time\"@EPSG/0/3338",
+        "metadata": {
+          "type": "xml",
+          "global": {
+            "Title": "'Daily Maximum 2m Temperature'"
+          }
+        },
+        "slicer": {
+          "type": "netcdf",
+          "pixelIsPoint": true,
+          "bands": [
+            {
+              "name": "t2_max",
+              "identifier": "t2_max"
+            }
+          ],
+          "axes": {
+            "time": {
+              "statements": "from datetime import datetime; import netCDF4",
+              "min": "netCDF4.num2date(${netcdf:variable:time:min}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "max": "netCDF4.num2date(${netcdf:variable:time:max}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "directPositions": "[netCDF4.num2date(x, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\") for x in ${netcdf:variable:time}]",
+              "gridOrder": 0,
+              "type": "ansidate",
+              "irregular": true
+            },
+            "X": {
+              "min": "${netcdf:variable:x:min}",
+              "max": "${netcdf:variable:x:max}",
+              "resolution": "${netcdf:variable:x:resolution}",
+              "gridOrder": 2
+            },
+            "Y": {
+              "min": "${netcdf:variable:y:min}",
+              "max": "${netcdf:variable:y:max}",
+              "resolution": "${netcdf:variable:y:resolution}",
+              "gridOrder": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ardac/daily_wrf_downscaled_era5/t2_mean_ingest_wcs_only.json
+++ b/ardac/daily_wrf_downscaled_era5/t2_mean_ingest_wcs_only.json
@@ -1,0 +1,68 @@
+{
+  "config": {
+    "service_url": "https://localhost/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "crs_resolver": "http://localhost:8080/def/",
+    "default_crs": "http://localhost:8080/def/crs/EPSG/0/3338",
+    "default_null_values": [
+      "nan"
+    ],
+    "mock": false,
+    "automated": true
+  },
+  "input": {
+    "coverage_id": "era5_4km_daily_t2_mean_wcs",
+    "paths": [
+      "t2_mean_merged.nc"
+    ]
+  },
+  "recipe": {
+    "name": "general_coverage",
+    "options": {
+      "import_order": "ascending",
+      "tiling": "ALIGNED [0:*, 0:7, 0:7] TILE SIZE 8388608",
+      "coverage": {
+        "crs": "OGC/0/AnsiDate?axis-label=\"time\"@EPSG/0/3338",
+        "metadata": {
+          "type": "xml",
+          "global": {
+            "Title": "'Daily Mean 2m Temperature'"
+          }
+        },
+        "slicer": {
+          "type": "netcdf",
+          "pixelIsPoint": true,
+          "bands": [
+            {
+              "name": "t2_mean",
+              "identifier": "t2_mean"
+            }
+          ],
+          "axes": {
+            "time": {
+              "statements": "from datetime import datetime; import netCDF4",
+              "min": "netCDF4.num2date(${netcdf:variable:time:min}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "max": "netCDF4.num2date(${netcdf:variable:time:max}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "directPositions": "[netCDF4.num2date(x, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\") for x in ${netcdf:variable:time}]",
+              "gridOrder": 0,
+              "type": "ansidate",
+              "irregular": true
+            },
+            "X": {
+              "min": "${netcdf:variable:x:min}",
+              "max": "${netcdf:variable:x:max}",
+              "resolution": "${netcdf:variable:x:resolution}",
+              "gridOrder": 2
+            },
+            "Y": {
+              "min": "${netcdf:variable:y:min}",
+              "max": "${netcdf:variable:y:max}",
+              "resolution": "${netcdf:variable:y:resolution}",
+              "gridOrder": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ardac/daily_wrf_downscaled_era5/t2_min_ingest_wcs_only.json
+++ b/ardac/daily_wrf_downscaled_era5/t2_min_ingest_wcs_only.json
@@ -1,0 +1,68 @@
+{
+  "config": {
+    "service_url": "https://localhost/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "crs_resolver": "http://localhost:8080/def/",
+    "default_crs": "http://localhost:8080/def/crs/EPSG/0/3338",
+    "default_null_values": [
+      "nan"
+    ],
+    "mock": false,
+    "automated": true
+  },
+  "input": {
+    "coverage_id": "era5_4km_daily_t2_min_wcs",
+    "paths": [
+      "t2_min_merged.nc"
+    ]
+  },
+  "recipe": {
+    "name": "general_coverage",
+    "options": {
+      "import_order": "ascending",
+      "tiling": "ALIGNED [0:*, 0:7, 0:7] TILE SIZE 8388608",
+      "coverage": {
+        "crs": "OGC/0/AnsiDate?axis-label=\"time\"@EPSG/0/3338",
+        "metadata": {
+          "type": "xml",
+          "global": {
+            "Title": "'Daily Minimum 2m Temperature'"
+          }
+        },
+        "slicer": {
+          "type": "netcdf",
+          "pixelIsPoint": true,
+          "bands": [
+            {
+              "name": "t2_min",
+              "identifier": "t2_min"
+            }
+          ],
+          "axes": {
+            "time": {
+              "statements": "from datetime import datetime; import netCDF4",
+              "min": "netCDF4.num2date(${netcdf:variable:time:min}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "max": "netCDF4.num2date(${netcdf:variable:time:max}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "directPositions": "[netCDF4.num2date(x, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\") for x in ${netcdf:variable:time}]",
+              "gridOrder": 0,
+              "type": "ansidate",
+              "irregular": true
+            },
+            "X": {
+              "min": "${netcdf:variable:x:min}",
+              "max": "${netcdf:variable:x:max}",
+              "resolution": "${netcdf:variable:x:resolution}",
+              "gridOrder": 2
+            },
+            "Y": {
+              "min": "${netcdf:variable:y:min}",
+              "max": "${netcdf:variable:y:max}",
+              "resolution": "${netcdf:variable:y:resolution}",
+              "gridOrder": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ardac/daily_wrf_downscaled_era5/wdir10_mean_ingest_wcs_only.json
+++ b/ardac/daily_wrf_downscaled_era5/wdir10_mean_ingest_wcs_only.json
@@ -1,0 +1,68 @@
+{
+  "config": {
+    "service_url": "https://localhost/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "crs_resolver": "http://localhost:8080/def/",
+    "default_crs": "http://localhost:8080/def/crs/EPSG/0/3338",
+    "default_null_values": [
+      "nan"
+    ],
+    "mock": false,
+    "automated": true
+  },
+  "input": {
+    "coverage_id": "era5_4km_daily_wdir10_mean_wcs",
+    "paths": [
+      "wdir10_mean_merged.nc"
+    ]
+  },
+  "recipe": {
+    "name": "general_coverage",
+    "options": {
+      "import_order": "ascending",
+      "tiling": "ALIGNED [0:*, 0:7, 0:7] TILE SIZE 8388608",
+      "coverage": {
+        "crs": "OGC/0/AnsiDate?axis-label=\"time\"@EPSG/0/3338",
+        "metadata": {
+          "type": "xml",
+          "global": {
+            "Title": "'Daily Mean 10m Wind Direction'"
+          }
+        },
+        "slicer": {
+          "type": "netcdf",
+          "pixelIsPoint": true,
+          "bands": [
+            {
+              "name": "wdir10_mean",
+              "identifier": "wdir10_mean"
+            }
+          ],
+          "axes": {
+            "time": {
+              "statements": "from datetime import datetime; import netCDF4",
+              "min": "netCDF4.num2date(${netcdf:variable:time:min}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "max": "netCDF4.num2date(${netcdf:variable:time:max}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "directPositions": "[netCDF4.num2date(x, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\") for x in ${netcdf:variable:time}]",
+              "gridOrder": 0,
+              "type": "ansidate",
+              "irregular": true
+            },
+            "X": {
+              "min": "${netcdf:variable:x:min}",
+              "max": "${netcdf:variable:x:max}",
+              "resolution": "${netcdf:variable:x:resolution}",
+              "gridOrder": 2
+            },
+            "Y": {
+              "min": "${netcdf:variable:y:min}",
+              "max": "${netcdf:variable:y:max}",
+              "resolution": "${netcdf:variable:y:resolution}",
+              "gridOrder": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ardac/daily_wrf_downscaled_era5/wspd10_max_ingest_wcs_only.json
+++ b/ardac/daily_wrf_downscaled_era5/wspd10_max_ingest_wcs_only.json
@@ -1,0 +1,68 @@
+{
+  "config": {
+    "service_url": "https://localhost/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "crs_resolver": "http://localhost:8080/def/",
+    "default_crs": "http://localhost:8080/def/crs/EPSG/0/3338",
+    "default_null_values": [
+      "nan"
+    ],
+    "mock": false,
+    "automated": true
+  },
+  "input": {
+    "coverage_id": "era5_4km_daily_wspd10_max_wcs",
+    "paths": [
+      "wspd10_max_merged.nc"
+    ]
+  },
+  "recipe": {
+    "name": "general_coverage",
+    "options": {
+      "import_order": "ascending",
+      "tiling": "ALIGNED [0:*, 0:7, 0:7] TILE SIZE 8388608",
+      "coverage": {
+        "crs": "OGC/0/AnsiDate?axis-label=\"time\"@EPSG/0/3338",
+        "metadata": {
+          "type": "xml",
+          "global": {
+            "Title": "'Daily Maximum 10m Wind Speed'"
+          }
+        },
+        "slicer": {
+          "type": "netcdf",
+          "pixelIsPoint": true,
+          "bands": [
+            {
+              "name": "wspd10_max",
+              "identifier": "wspd10_max"
+            }
+          ],
+          "axes": {
+            "time": {
+              "statements": "from datetime import datetime; import netCDF4",
+              "min": "netCDF4.num2date(${netcdf:variable:time:min}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "max": "netCDF4.num2date(${netcdf:variable:time:max}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "directPositions": "[netCDF4.num2date(x, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\") for x in ${netcdf:variable:time}]",
+              "gridOrder": 0,
+              "type": "ansidate",
+              "irregular": true
+            },
+            "X": {
+              "min": "${netcdf:variable:x:min}",
+              "max": "${netcdf:variable:x:max}",
+              "resolution": "${netcdf:variable:x:resolution}",
+              "gridOrder": 2
+            },
+            "Y": {
+              "min": "${netcdf:variable:y:min}",
+              "max": "${netcdf:variable:y:max}",
+              "resolution": "${netcdf:variable:y:resolution}",
+              "gridOrder": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ardac/daily_wrf_downscaled_era5/wspd10_mean_ingest_wcs_only.json
+++ b/ardac/daily_wrf_downscaled_era5/wspd10_mean_ingest_wcs_only.json
@@ -1,0 +1,68 @@
+{
+  "config": {
+    "service_url": "https://localhost/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "crs_resolver": "http://localhost:8080/def/",
+    "default_crs": "http://localhost:8080/def/crs/EPSG/0/3338",
+    "default_null_values": [
+      "nan"
+    ],
+    "mock": false,
+    "automated": true
+  },
+  "input": {
+    "coverage_id": "era5_4km_daily_wspd10_mean_wcs",
+    "paths": [
+      "wspd10_mean_merged.nc"
+    ]
+  },
+  "recipe": {
+    "name": "general_coverage",
+    "options": {
+      "import_order": "ascending",
+      "tiling": "ALIGNED [0:*, 0:7, 0:7] TILE SIZE 8388608",
+      "coverage": {
+        "crs": "OGC/0/AnsiDate?axis-label=\"time\"@EPSG/0/3338",
+        "metadata": {
+          "type": "xml",
+          "global": {
+            "Title": "'Daily Mean 10m Wind Speed'"
+          }
+        },
+        "slicer": {
+          "type": "netcdf",
+          "pixelIsPoint": true,
+          "bands": [
+            {
+              "name": "wspd10_mean",
+              "identifier": "wspd10_mean"
+            }
+          ],
+          "axes": {
+            "time": {
+              "statements": "from datetime import datetime; import netCDF4",
+              "min": "netCDF4.num2date(${netcdf:variable:time:min}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "max": "netCDF4.num2date(${netcdf:variable:time:max}, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\")",
+              "directPositions": "[netCDF4.num2date(x, '${netcdf:variable:time:units}', calendar='standard').strftime(\"%Y-%m-%dT%H:%M\") for x in ${netcdf:variable:time}]",
+              "gridOrder": 0,
+              "type": "ansidate",
+              "irregular": true
+            },
+            "X": {
+              "min": "${netcdf:variable:x:min}",
+              "max": "${netcdf:variable:x:max}",
+              "resolution": "${netcdf:variable:x:resolution}",
+              "gridOrder": 2
+            },
+            "Y": {
+              "min": "${netcdf:variable:y:min}",
+              "max": "${netcdf:variable:y:max}",
+              "resolution": "${netcdf:variable:y:resolution}",
+              "gridOrder": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds multiple new ingest recipes corresponding to new ERA5 WRF-Downscaled 4 km coverages that have been optimized for WCS queries. New coverage ids have a suffix of  `_wcs` attached.

These coverages are constructed with a tiling that will optimize queries that are small in X-Y, but long in time, e.g., "Give me the full time series of data at this location".

The new `_wcs` coverages will not support WMS. This is intentional - we've omitted the wms_import ingredient from the recipe. We are electing to do this because we know that the typical WMS query scheme (single time slice, full spatial domain) will not be responsive with this WCS specific tiling scheme.

To test this PR, see the XREF'd Prefect PR.

Closes #133 