### PR TITLE
Time attrs

### DIFF
--- a/ardac/cmip6_indicators/combine_indicators_ensemble.py
+++ b/ardac/cmip6_indicators/combine_indicators_ensemble.py
@@ -174,6 +174,8 @@ def convert_time(ds):
     ds["time"].attrs["calendar"] = "standard"
     ds["time"].attrs["long_name"] = "time"
     ds["time"].attrs["standard_name"] = "time"
+    ds["time"].attrs["min_value"] = ds["time"].min().values
+    ds["time"].attrs["max_value"] = ds["time"].max().values
 
     return ds
 


### PR DESCRIPTION
Simple addition of min and max attributes to the time dimension of the CF-compliant CMIP6 indicators coverage. This will allow validation of API requests from metadata, so we don't need to request the actual data for validation.