### PR TITLE
ERA5 4 km Elevation Grid

### DIFF
--- a/ardac/elevation_grids/elevation_4km_wrf_downscaled_era5.json
+++ b/ardac/elevation_grids/elevation_4km_wrf_downscaled_era5.json
@@ -31,7 +31,7 @@
       "tiling": "ALIGNED [0:127, 0:127] tile size 65536",
       "import_order": "ascending",
       "coverage": {
-        "crs": "http://www.opengis.net/def/crs/EPSG/0/3338",
+        "crs": "EPSG/0/3338",
         "metadata": {
           "type": "xml",
           "global": {


### PR DESCRIPTION
This PR adds a new coverage, `era5_4km_elevation`, based on the elevation file used in the WRF dynamical downscaling of the ERA5 reanalysis. This elevation grid underpins those data products, as well as the CMIP6 downscaled products.

Some notes:

- WCS requests come back in about 200 ms (mean of 5 jittered requests) in my benchmark
- There is a WMS style for general completeness, but we could omit this because AFAIK at this time there is no actual client need to render a GetMap of this layer. However, the cost is just a single style hook, and maybe this could be used in an ARDAC data story "Elevation of Grid Cells in Modeled Data, And You"
- To test this PR, just run the ingest. You can safely drop the in-place coverage of the same name before your attempt.